### PR TITLE
Change formatting for Accepted and Declined gambits

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -15,7 +15,7 @@ A00	Clemenz Opening	rnbqkbnr/pppppppp/8/8/8/7P/PPPPPPP1/RNBQKBNR b KQkq -	h2h3
 A00	Clemenz Opening: Spike Lee Gambit	rnbqkbnr/ppppppp1/8/7p/6P1/7P/PPPPPP2/RNBQKBNR b KQkq -	h2h3 h7h5 g2g4
 A00	Crab Opening	rnbqkbnr/pppp1ppp/8/4p3/P6P/8/1PPPPPP1/RNBQKBNR b KQkq -	a2a4 e7e5 h2h4
 A00	Creepy Crawly Formation: Classical Defense	rnbqkbnr/ppp2ppp/8/3pp3/8/P6P/1PPPPPP1/RNBQKBNR w KQkq -	h2h3 d7d5 a2a3 e7e5
-A00	Englund Gambit Declined, Reversed French	rnbqkbnr/pppp1ppp/8/4p3/3P4/4P3/PPP2PPP/RNBQKBNR b KQkq -	e2e3 e7e5 d2d4
+A00	Englund Gambit Declined: Reversed French	rnbqkbnr/pppp1ppp/8/4p3/3P4/4P3/PPP2PPP/RNBQKBNR b KQkq -	e2e3 e7e5 d2d4
 A00	Formation: Cabbage Attack	r1bq1rk1/ppp2ppp/2nb1n2/3pp3/P7/1PP1P1P1/1B1P1P1P/RN1QKBNR b KQ -	c2c3 e7e5 a2a3 d7d5 b2b3 g8f6 c1b2 b8c6 a3a4 f8d6 g2g3 e8g8 e2e3
 A00	Formation: Hippopotamus Attack	r1bq1rk1/ppp2ppp/2nb1n2/3pp3/8/PPPPPPP1/7P/RNBQKBNR b KQ -	a2a3 e7e5 b2b3 d7d5 c2c3 g8f6 d2d3 b8c6 e2e3 f8d6 f2f3 e8g8 g2g3
 A00	Formation: Shy Attack	r1bq1rk1/ppp2ppp/2nb1n2/3pp3/8/P2PP1PP/1PPN1PB1/R1BQK1NR b KQ -	a2a3 e7e5 g2g3 d7d5 f1g2 g8f6 d2d3 b8c6 b1d2 f8d6 e2e3 e8g8 h2h3
@@ -424,7 +424,7 @@ A40	English Defense: Perrin Variation	r2qkbnr/pbpp1ppp/1pn1p3/8/2PPP3/3B4/PP3PPP
 A40	English Defense: Poli Gambit	rn1qkb1r/pbpp2pp/1p2p2n/5P2/2PP4/5P2/PP4PP/RNBQKBNR w KQkq -	d2d4 e7e6 c2c4 b7b6 e2e4 c8b7 f2f3 f7f5 e4f5 g8h6
 A40	English Defense	rnbqkbnr/p1pp1ppp/1p2p3/8/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 e7e6 c2c4 b7b6
 A40	English Defense	rnbqkbnr/p1pppppp/1p6/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -	d2d4 b7b6
-A40	Englund Gambit Complex Declined, Diemer Counterattack	rnb1k1nr/pppp1ppp/8/2bPp3/4P2q/8/PPP2PPP/RNBQKBNR w KQkq -	d2d4 e7e5 d4d5 f8c5 e2e4 d8h4
+A40	Englund Gambit Complex Declined: Diemer Counterattack	rnb1k1nr/pppp1ppp/8/2bPp3/4P2q/8/PPP2PPP/RNBQKBNR w KQkq -	d2d4 e7e5 d4d5 f8c5 e2e4 d8h4
 A40	Englund Gambit Complex Declined	rnbqkbnr/pppp1ppp/8/3Pp3/8/8/PPP1PPPP/RNBQKBNR b KQkq -	d2d4 e7e5 d4d5
 A40	Englund Gambit Complex: Englund Gambit	r1b1kbnr/ppppqppp/2n5/4P3/8/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 d4e5 b8c6 g1f3 d8e7
 A40	Englund Gambit Complex: Felbecker Gambit	r1bqk1nr/pppp1ppp/2n5/2b1P3/8/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 d4e5 b8c6 g1f3 f8c5
@@ -435,10 +435,10 @@ A40	Englund Gambit Complex: Soller Gambit	rnbqkbnr/pppp2pp/5p2/4P3/8/8/PPP1PPPP/
 A40	Englund Gambit Complex: Stockholm Variation	r1b1kbnr/ppppqppp/2n5/3QP3/8/5N2/PPP1PPPP/RNB1KB1R b KQkq -	d2d4 e7e5 d4e5 b8c6 g1f3 d8e7 d1d5
 A40	Englund Gambit Complex: Zilbermints Gambit	r1bqkb1r/ppppnppp/2n5/4P3/8/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 d4e5 b8c6 g1f3 g8e7
 A40	Englund Gambit Complex: Zilbermints Gambit	r1bqkbnr/pppp1pp1/2n4p/4P3/8/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 d4e5 b8c6 g1f3 h7h6
-A40	Englund Gambit Declined, Reversed Alekhine	rnbqkbnr/pppp1ppp/8/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R b KQkq -	d2d4 e7e5 g1f3
-A40	Englund Gambit Declined, Reversed Brooklyn	rnbqkbnr/pppp1ppp/8/8/3Pp3/8/PPP1PPPP/RNBQKBNR b KQkq -	d2d4 e7e5 g1f3 e5e4 f3g1
-A40	Englund Gambit Declined, Reversed Krebs	rnbqkbnr/pppp1ppp/8/8/3Pp3/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 g1f3 e5e4
-A40	Englund Gambit Declined, Reversed Mokele Mbembe	rnbqkbnr/pppp1ppp/8/4N3/3Pp3/8/PPP1PPPP/RNBQKB1R b KQkq -	d2d4 e7e5 g1f3 e5e4 f3e5
+A40	Englund Gambit Declined: Reversed Alekhine	rnbqkbnr/pppp1ppp/8/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R b KQkq -	d2d4 e7e5 g1f3
+A40	Englund Gambit Declined: Reversed Brooklyn	rnbqkbnr/pppp1ppp/8/8/3Pp3/8/PPP1PPPP/RNBQKBNR b KQkq -	d2d4 e7e5 g1f3 e5e4 f3g1
+A40	Englund Gambit Declined: Reversed Krebs	rnbqkbnr/pppp1ppp/8/8/3Pp3/5N2/PPP1PPPP/RNBQKB1R w KQkq -	d2d4 e7e5 g1f3 e5e4
+A40	Englund Gambit Declined: Reversed Mokele Mbembe	rnbqkbnr/pppp1ppp/8/4N3/3Pp3/8/PPP1PPPP/RNBQKB1R b KQkq -	d2d4 e7e5 g1f3 e5e4 f3e5
 A40	Englund Gambit	rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -	d2d4 e7e5
 A40	Horwitz Defense	rnbqkbnr/pppp1ppp/4p3/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -	d2d4 e7e6
 A40	Kangaroo Defense: Keres Defense, Transpositional Variation	rnbqk1nr/pppp1ppp/4p3/8/1bPP4/2N5/PP2PPPP/R1BQKBNR b KQkq -	d2d4 e7e6 c2c4 f8b4 b1c3
@@ -506,8 +506,8 @@ A43	Queen's Pawn Game: Liedmann Gambit	rnbqkbnr/pp1ppppp/8/8/2Pp4/4P3/PP3PPP/RNB
 A44	Old Benoni Defense	rnbqkbnr/pp1p1ppp/8/2pPp3/8/8/PPP1PPPP/RNBQKBNR w KQkq e6	d2d4 c7c5 d4d5 e7e5
 A44	Semi-Benoni	rnbqkbnr/pp3ppp/3p4/2pPp3/4P3/8/PPP2PPP/RNBQKBNR w KQkq -	d2d4 c7c5 d4d5 e7e5 e2e4 d7d6
 A45	Amazon Attack: Siberian Attack	rnbqkb1r/ppp1pppp/5n2/3p4/3P4/2NQ4/PPP1PPPP/R1B1KBNR b KQkq -	d2d4 g8f6 b1c3 d7d5 d1d3
-A45	Blackmar-Diemer Gambit Declined, O'Kelly Defense	rnbqkb1r/pp2pppp/2p2n2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 f2f3 d7d5 e2e4 d5e4 b1c3 c7c6
-A45	Blackmar-Diemer Gambit Declined, Weinsbach Declination	rnbqkb1r/ppp2ppp/4pn2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 f2f3 e7e6 e2e4 d5e4
+A45	Blackmar-Diemer Gambit Declined: O'Kelly Defense	rnbqkb1r/pp2pppp/2p2n2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 f2f3 d7d5 e2e4 d5e4 b1c3 c7c6
+A45	Blackmar-Diemer Gambit Declined: Weinsbach Declination	rnbqkb1r/ppp2ppp/4pn2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 f2f3 e7e6 e2e4 d5e4
 A45	Bronstein Gambit	rnbqkb1r/pppppppp/5n2/8/3P2P1/8/PPP1PP1P/RNBQKBNR b KQkq -	d2d4 g8f6 g2g4
 A45	Canard Opening	rnbqkb1r/pppppppp/5n2/8/3P1P2/8/PPP1P1PP/RNBQKBNR b KQkq -	d2d4 g8f6 f2f4
 A45	Indian Game: Gedult Attack, Gedult Attack	rnbqkb1r/ppp1pppp/5n2/3p4/3P2P1/5P2/PPP1P2P/RNBQKBNR b KQkq -	d2d4 g8f6 f2f3 d7d5 g2g4
@@ -602,29 +602,29 @@ A56	Benoni Defense	rnbqkb1r/pp1ppppp/5n2/2p5/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -	d2
 A56	Benoni Defense: Weenink Variation	rnbqkb1r/pp1p1ppp/4pn2/2P5/2P5/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4c5 e7e6
 A56	Grünfeld Defense: Three Knights Variation, Burille Variation, Reversed Tarrasch	r1bq1rk1/pp2ppbp/2n2np1/3p4/2PP4/2N2N2/PP2BPPP/R1BQ1RK1 w - -	d2d4 g8f6 c2c4 c7c5 e2e3 g7g6 b1c3 f8g7 g1f3 e8g8 f1e2 c5d4 e3d4 d7d5 e1g1 b8c6
 A56	Vulture Defense	rnbqkb1r/pp1ppppp/8/2pP4/2P1n3/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 f6e4
-A57	Benko Gambit Accepted, Dlugy Variation	rnbqkb1r/3ppppp/p4n2/1PpP4/8/5P2/PP2P1PP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 f2f3
-A57	Benko Gambit Accepted, Modern Variation	rnbqkb1r/3ppppp/p4n2/1PpP4/8/4P3/PP3PPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 e2e3
-A57	Benko Gambit Accepted, Pawn Return Variation	rnbqkb1r/3ppppp/pP3n2/2pP4/8/8/PP2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5b6
+A57	Benko Gambit Accepted: Dlugy Variation	rnbqkb1r/3ppppp/p4n2/1PpP4/8/5P2/PP2P1PP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 f2f3
+A57	Benko Gambit Accepted: Modern Variation	rnbqkb1r/3ppppp/p4n2/1PpP4/8/4P3/PP3PPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 e2e3
+A57	Benko Gambit Accepted: Pawn Return Variation	rnbqkb1r/3ppppp/pP3n2/2pP4/8/8/PP2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5b6
 A57	Benko Gambit Accepted	rnbqkb1r/3ppppp/p4n2/1PpP4/8/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6
-A57	Benko Gambit Declined, Bishop Attack	rnbqkb1r/p2ppppp/5n2/1ppP2B1/2P5/8/PP2PPPP/RN1QKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c1g5
-A57	Benko Gambit Declined, Hjørring Countergambit	rnbqkb1r/p2ppppp/5n2/1ppP4/2P1P3/8/PP3PPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 e2e4
-A57	Benko Gambit Declined, Main Line	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/5N2/PP2PPPP/RNBQKB1R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 g1f3
-A57	Benko Gambit Declined, Pseudo-Sämisch	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/5P2/PP2P1PP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 f2f3
-A57	Benko Gambit Declined, Quiet Line	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/8/PP1NPPPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 b1d2
-A57	Benko Gambit Declined, Sosonko Variation	rnbqkb1r/p2ppppp/5n2/1ppP4/P1P5/8/1P2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 a2a4
+A57	Benko Gambit Declined: Bishop Attack	rnbqkb1r/p2ppppp/5n2/1ppP2B1/2P5/8/PP2PPPP/RN1QKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c1g5
+A57	Benko Gambit Declined: Hjørring Countergambit	rnbqkb1r/p2ppppp/5n2/1ppP4/2P1P3/8/PP3PPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 e2e4
+A57	Benko Gambit Declined: Main Line	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/5N2/PP2PPPP/RNBQKB1R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 g1f3
+A57	Benko Gambit Declined: Pseudo-Sämisch	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/5P2/PP2P1PP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 f2f3
+A57	Benko Gambit Declined: Quiet Line	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/8/PP1NPPPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 b1d2
+A57	Benko Gambit Declined: Sosonko Variation	rnbqkb1r/p2ppppp/5n2/1ppP4/P1P5/8/1P2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 a2a4
 A57	Benko Gambit: Mutkin Countergambit	rnbqkb1r/p2ppppp/5n2/1ppP4/2P3P1/8/PP2PP1P/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 g2g4
 A57	Benko Gambit: Nescafe Frappe Attack	rnbqkb1r/4pppp/3p1n2/1NpP4/1pB1P3/8/PP3PPP/R1BQK1NR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b1c3 a6b5 e2e4 b5b4 c3b5 d7d6 f1c4
 A57	Benko Gambit	rnbqkb1r/p2ppppp/5n2/1ppP4/2P5/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5
 A57	Benko Gambit: Zaitsev System	rnbqkb1r/3ppppp/p4n2/1PpP4/8/2N5/PP2PPPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b1c3
 A57	Benko Gambit: Zaitsev Variation, Nescafe Frappe Attack	rnbqkb1r/3ppppp/5n2/1NpP4/1p2P3/8/PP3PPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b1c3 a6b5 e2e4 b5b4 c3b5
-A58	Benko Gambit Accepted, Central Storming Variation	rn1qkb1r/3ppp1p/b4np1/2pP4/5P2/2N5/PP2P1PP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 f2f4
-A58	Benko Gambit Accepted, Fianchetto Variation	rn1qk2r/4ppbp/b2p1np1/2pP4/8/2N2NP1/PP2PPBP/R1BQK2R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 g2g3 d7d6 f1g2 f8g7 g1f3
-A58	Benko Gambit Accepted, Fully Accepted Variation	rnbqkb1r/3ppppp/P4n2/2pP4/8/8/PP2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6
+A58	Benko Gambit Accepted: Central Storming Variation	rn1qkb1r/3ppp1p/b4np1/2pP4/5P2/2N5/PP2P1PP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 f2f4
+A58	Benko Gambit Accepted: Fianchetto Variation	rn1qk2r/4ppbp/b2p1np1/2pP4/8/2N2NP1/PP2PPBP/R1BQK2R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 g2g3 d7d6 f1g2 f8g7 g1f3
+A58	Benko Gambit Accepted: Fully Accepted Variation	rnbqkb1r/3ppppp/P4n2/2pP4/8/8/PP2PPPP/RNBQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6
 A58	Benko Gambit: Fianchetto Variation	rn1qkb1r/4pp1p/b2p1np1/2pP4/8/2N2NP1/PP2PP1P/R1BQKB1R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 c8a6 b1c3 d7d6 g1f3 g7g6 g2g3
 A58	Benko Gambit: Nd2 Variation	rn1qkb1r/4pp1p/b2p1np1/2pP4/8/2N5/PP1NPPPP/R1BQKB1R b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 c8a6 b1c3 d7d6 g1f3 g7g6 f3d2
-A59	Benko Gambit Accepted, King Walk Variation	rn1q1rk1/4ppbp/3p1np1/2pP4/4P3/2N2NP1/PP3PKP/R1BQ3R b - -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 g1f3 d7d6 e2e4 a6f1 e1f1 f8g7 g2g3 e8g8 f1g2
-A59	Benko Gambit Accepted, Yugoslav	rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N5/PP2NPPP/R1BQ1K1R b kq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 e2e4 a6f1 e1f1 d7d6 g1e2
-A59	Benko Gambit Accepted, Yugoslav	rn1qkb1r/4pppp/b2p1n2/2pP4/4P3/2N5/PP3PPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 c8a6 b1c3 d7d6 e2e4
+A59	Benko Gambit Accepted: King Walk Variation	rn1q1rk1/4ppbp/3p1np1/2pP4/4P3/2N2NP1/PP3PKP/R1BQ3R b - -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 g1f3 d7d6 e2e4 a6f1 e1f1 f8g7 g2g3 e8g8 f1g2
+A59	Benko Gambit Accepted: Yugoslav	rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N5/PP2NPPP/R1BQ1K1R b kq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 e2e4 a6f1 e1f1 d7d6 g1e2
+A59	Benko Gambit Accepted: Yugoslav	rn1qkb1r/4pppp/b2p1n2/2pP4/4P3/2N5/PP3PPP/R1BQKBNR b KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 c8a6 b1c3 d7d6 e2e4
 A59	Benko Gambit	rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N3P1/PP3P1P/R1BQ1KNR b kq -	d2d4 g8f6 c2c4 c7c5 d4d5 b7b5 c4b5 a7a6 b5a6 g7g6 b1c3 c8a6 e2e4 a6f1 e1f1 d7d6 g2g3
 A60	Benoni Defense: Modern Variation	rnbqkb1r/pp1p1ppp/4pn2/2pP4/2P5/8/PP2PPPP/RNBQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 e7e6
 A60	Benoni Defense: Modern Variation, Snake Variation	rnbqk2r/pp1p1ppp/3b1n2/2pP4/8/2N5/PP2PPPP/R1BQKBNR w KQkq -	d2d4 g8f6 c2c4 c7c5 d4d5 e7e6 b1c3 e6d5 c4d5 f8d6

--- a/b.tsv
+++ b/b.tsv
@@ -15,7 +15,7 @@ B00	Guatemala Defense	rn1qkbnr/p1pppppp/bp6/8/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -	e
 B00	Hippopotamus Defense	rnbqkb1r/ppppp2p/5ppn/8/2PPP3/8/PP3PPP/RNBQKBNR w KQkq -	e2e4 g8h6 d2d4 g7g6 c2c4 f7f6
 B00	Hippopotamus Defense	rnbqkb1r/pppppppp/7n/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq -	e2e4 g8h6
 B00	King's Pawn Game: Nimzowitsch Defense	r1bqkbnr/pppppppp/2n5/8/3PP3/8/PPP2PPP/RNBQKBNR b KQkq -	e2e4 b8c6 d2d4
-B00	King's Pawn Game: Nimzowitsch Defense: Wheeler Gambit	r1bqkbnr/pppppppp/2n5/8/3PP3/2P5/P4PPP/RNBQKBNR b KQkq -	e2e4 b8c6 b2b4 c6b4 c2c3 b4c6 d2d4
+B00	King's Pawn Game: Nimzowitsch Defense, Wheeler Gambit	r1bqkbnr/pppppppp/2n5/8/3PP3/2P5/P4PPP/RNBQKBNR b KQkq -	e2e4 b8c6 b2b4 c6b4 c2c3 b4c6 d2d4
 B00	King's Pawn	rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq -	e2e4
 B00	Lemming Defense	r1bqkbnr/pppppppp/n7/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq -	e2e4 b8a6
 B00	Lion Defense: Lion's Jaw	rnbqkb1r/ppp1pppp/3p1n2/8/3PP3/5P2/PPP3PP/RNBQKBNR b KQkq -	e2e4 d7d6 d2d4 g8f6 f2f3

--- a/c.tsv
+++ b/c.tsv
@@ -214,13 +214,13 @@ C21	Center Game: Lanc-Arnold Gambit, Schippler Gambit	rnbqk1nr/pppp1ppp/8/2b5/2B
 C21	Center Game	rnbqkbnr/pppp1ppp/8/8/3QP3/8/PPP2PPP/RNB1KBNR b KQkq -	e2e4 e7e5 d2d4 e5d4 d1d4
 C21	Center Game: Ross Gambit	rnbqkbnr/pppp1ppp/8/8/3pP3/3B4/PPP2PPP/RNBQK1NR b KQkq -	e2e4 e7e5 d2d4 e5d4 f1d3
 C21	Center Game: von der Lasa Gambit	rnbqkbnr/pppp1ppp/8/8/2BpP3/8/PPP2PPP/RNBQK1NR b KQkq -	e2e4 e7e5 d2d4 e5d4 f1c4
-C21	Danish Gambit Accepted, Chigorin Defense	rnb1kbnr/ppppqppp/8/8/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 d8e7
-C21	Danish Gambit Accepted, Classical Defense	rnbqkb1r/pppp1ppp/5n2/8/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 g8f6
-C21	Danish Gambit Accepted, Copenhagen Defense	rnbqk1nr/pppp1ppp/8/8/1bB1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 f8b4
+C21	Danish Gambit Accepted: Chigorin Defense	rnb1kbnr/ppppqppp/8/8/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 d8e7
+C21	Danish Gambit Accepted: Classical Defense	rnbqkb1r/pppp1ppp/5n2/8/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 g8f6
+C21	Danish Gambit Accepted: Copenhagen Defense	rnbqk1nr/pppp1ppp/8/8/1bB1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 f8b4
 C21	Danish Gambit Accepted	rnbqkbnr/pppp1ppp/8/8/2B1P3/8/PB3PPP/RN1QK1NR b KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2
-C21	Danish Gambit Accepted, Schlechter Defense	rnbqkbnr/ppp2ppp/8/3p4/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 d7d5
-C21	Danish Gambit Accepted, Svenonius Defense	rnbqkb1r/ppppnppp/8/8/3pP3/2P5/PP3PPP/RNBQKBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 g8e7
-C21	Danish Gambit Declined, Sorensen Defense	rnbqkbnr/ppp2ppp/8/3p4/3pP3/2P5/PP3PPP/RNBQKBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d7d5
+C21	Danish Gambit Accepted: Schlechter Defense	rnbqkbnr/ppp2ppp/8/3p4/2B1P3/8/PB3PPP/RN1QK1NR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d4c3 f1c4 c3b2 c1b2 d7d5
+C21	Danish Gambit Accepted: Svenonius Defense	rnbqkb1r/ppppnppp/8/8/3pP3/2P5/PP3PPP/RNBQKBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 g8e7
+C21	Danish Gambit Declined: Sorensen Defense	rnbqkbnr/ppp2ppp/8/3p4/3pP3/2P5/PP3PPP/RNBQKBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3 d7d5
 C21	Danish Gambit	rnbqkbnr/pppp1ppp/8/8/3pP3/2P5/PP3PPP/RNBQKBNR b KQkq -	e2e4 e7e5 d2d4 e5d4 c2c3
 C22	Center Game: Berger Variation	r1bqkb1r/pppp1ppp/2n2n2/8/4P3/4Q3/PPP2PPP/RNB1KBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 d1d4 b8c6 d4e3 g8f6
 C22	Center Game: Charousek Variation	r1bqk1nr/ppppbppp/2n5/8/4P3/2P1Q3/PP3PPP/RNB1KBNR w KQkq -	e2e4 e7e5 d2d4 e5d4 d1d4 b8c6 d4e3 f8b4 c2c3 b4e7
@@ -327,25 +327,25 @@ C30	King's Gambit Declined: Classical, Hanham Variation	r1bqk1nr/pppn1ppp/3p4/2b
 C30	King's Gambit Declined: Classical, Réti Variation	rnbqk1nr/ppp3pp/8/2b2p2/2BpP3/2P2N2/PP4PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3 f7f5 f4e5 d6e5 d2d4 e5d4 f1c4
 C30	King's Gambit Declined: Classical, Soldatenkov Variation	rnbqk1nr/ppp2ppp/3p4/2b1P3/4P3/5N2/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 f4e5
 C30	King's Gambit Declined: Classical, Svenonius Variation	r2qk2r/ppp2ppp/2np1n2/2b5/2B1Pp2/2NP1Q1P/PPP3P1/R1B1K2R w KQkq -	e2e4 e7e5 f1c4 b8c6 b1c3 g8f6 d2d3 f8c5 f2f4 d7d6 g1f3 c8g4 h2h3 g4f3 d1f3 e5f4
-C30	King's Gambit Declined, Classical Variation, Euwe Attack	rn1qk1nr/ppp2ppp/8/2b1p3/Q3P1b1/2P2N2/PP1P2PP/RNB1KB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3 c8g4 f4e5 d6e5 d1a4
-C30	King's Gambit Declined, Classical Variation	rnbqk1nr/ppp2ppp/3p4/2b1p3/4PP2/2P2N2/PP1P2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3
-C30	King's Gambit Declined, Classical Variation	rnbqk1nr/pppp1ppp/8/2b1p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f8c5
-C30	King's Gambit Declined, Classical Variation, Rotlewi Countergambit	rnbqk1nr/ppp2ppp/3p4/2b1p3/1P2PP2/5N2/P1PP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 b2b4
-C30	King's Gambit Declined, Classical Variation, Rubinstein Countergambit	rnbqk1nr/ppp3pp/3p4/2b1pp2/4PP2/2P2N2/PP1P2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3 f7f5
-C30	King's Gambit Declined, Hobbs-Zilbermints Gambit	r1bqkbnr/pppp1p2/2n4p/4p1P1/4P3/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 g7g5 f4g5 h7h6
-C30	King's Gambit Declined, Keene Defense	rnb1kbnr/ppppqppp/8/4p3/4PP2/6P1/PPPP3P/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 d8h4 g2g3 h4e7
+C30	King's Gambit Declined: Classical Variation, Euwe Attack	rn1qk1nr/ppp2ppp/8/2b1p3/Q3P1b1/2P2N2/PP1P2PP/RNB1KB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3 c8g4 f4e5 d6e5 d1a4
+C30	King's Gambit Declined: Classical Variation	rnbqk1nr/ppp2ppp/3p4/2b1p3/4PP2/2P2N2/PP1P2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3
+C30	King's Gambit Declined: Classical Variation	rnbqk1nr/pppp1ppp/8/2b1p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f8c5
+C30	King's Gambit Declined: Classical Variation, Rotlewi Countergambit	rnbqk1nr/ppp2ppp/3p4/2b1p3/1P2PP2/5N2/P1PP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 b2b4
+C30	King's Gambit Declined: Classical Variation, Rubinstein Countergambit	rnbqk1nr/ppp3pp/3p4/2b1pp2/4PP2/2P2N2/PP1P2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 d7d6 c2c3 f7f5
+C30	King's Gambit Declined: Hobbs-Zilbermints Gambit	r1bqkbnr/pppp1p2/2n4p/4p1P1/4P3/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 g7g5 f4g5 h7h6
+C30	King's Gambit Declined: Keene Defense	rnb1kbnr/ppppqppp/8/4p3/4PP2/6P1/PPPP3P/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 d8h4 g2g3 h4e7
 C30	King's Gambit Declined: Keene's Defense	rnb1kbnr/pppp1ppp/8/4p3/4PP1q/6P1/PPPP3P/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 d8h4 g2g3
 C30	King's Gambit Declined: Keene's Defense	rnb1kbnr/pppp1ppp/8/4p3/4PP1q/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 d8h4
-C30	King's Gambit Declined, Mafia Defense	rnbqkbnr/pp1p1ppp/8/2p1p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 c7c5 f2f4 e7e5
-C30	King's Gambit Declined, Miles Defense	r1bqkbnr/pppp2pp/2n5/4pp2/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 f7f5
+C30	King's Gambit Declined: Mafia Defense	rnbqkbnr/pp1p1ppp/8/2p1p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 c7c5 f2f4 e7e5
+C30	King's Gambit Declined: Miles Defense	r1bqkbnr/pppp2pp/2n5/4pp2/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 f7f5
 C30	King's Gambit Declined: Norwalde Variation, Bücker Gambit	rnb1k1nr/pppp1ppp/8/4p3/1bB1Pq2/2N2N2/PPPP2PP/R1BQK2R b KQkq -	e2e4 e7e5 f2f4 d8f6 b1c3 f6f4 g1f3 f8b4 f1c4
-C30	King's Gambit Declined, Norwalde Variation	rnb1kbnr/pppp1ppp/5q2/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 d8f6
-C30	King's Gambit Declined, Norwalde Variation, Schubert Variation	rnb1kbnr/pppp1ppp/8/4p3/3PPq2/2N5/PPP3PP/R1BQKBNR b KQkq -	e2e4 e7e5 f2f4 d8f6 b1c3 f6f4 d2d4
-C30	King's Gambit Declined, Petrov's Defense	rnbqkb1r/pppp1ppp/5n2/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 g8f6
-C30	King's Gambit Declined, Queen's Knight Defense	r1bqkbnr/pppp1ppp/2n5/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 b8c6
-C30	King's Gambit Declined, Senechaud Countergambit	rnbqk1nr/pppp1p1p/8/2b1p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 g7g5
-C30	King's Gambit Declined, Soller-Zilbermints Gambit	r1bqkbnr/pppp2pp/2n2p2/4P3/4P3/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f7f6 f4e5 b8c6
-C30	King's Gambit Declined, Zilbermints Double Gambit	r1bqkbnr/pppp1p1p/2n5/4p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 g7g5
+C30	King's Gambit Declined: Norwalde Variation	rnb1kbnr/pppp1ppp/5q2/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 d8f6
+C30	King's Gambit Declined: Norwalde Variation, Schubert Variation	rnb1kbnr/pppp1ppp/8/4p3/3PPq2/2N5/PPP3PP/R1BQKBNR b KQkq -	e2e4 e7e5 f2f4 d8f6 b1c3 f6f4 d2d4
+C30	King's Gambit Declined: Petrov's Defense	rnbqkb1r/pppp1ppp/5n2/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 g8f6
+C30	King's Gambit Declined: Queen's Knight Defense	r1bqkbnr/pppp1ppp/2n5/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 b8c6
+C30	King's Gambit Declined: Senechaud Countergambit	rnbqk1nr/pppp1p1p/8/2b1p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 f8c5 g1f3 g7g5
+C30	King's Gambit Declined: Soller-Zilbermints Gambit	r1bqkbnr/pppp2pp/2n2p2/4P3/4P3/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f7f6 f4e5 b8c6
+C30	King's Gambit Declined: Zilbermints Double Gambit	r1bqkbnr/pppp1p1p/2n5/4p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 b8c6 g1f3 g7g5
 C30	King's Gambit: Panteldakis Countergambit, Greco Variation	rnb1kbnr/pppp2pp/8/4pP2/5P1q/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f7f5 e4f5 d8h4
 C30	King's Gambit: Panteldakis Countergambit, Pawn Sacrifice Line	rnb1kbnr/ppppq2p/6P1/7Q/5p2/8/PPPP2PP/RNBK1BNR b kq -	e2e4 e7e5 f2f4 f7f5 e4f5 e5f4 d1h5 g7g6 f5g6 d8e7 e1d1
 C30	King's Gambit: Panteldakis Countergambit	rnbqkbnr/pppp2pp/8/4pp2/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 f7f5
@@ -377,118 +377,118 @@ C32	King's Gambit, Falkbeer Countergambit, Charousek Gambit Accepted	rnbqkb1r/pp
 C32	King's Gambit, Falkbeer Countergambit, Charousek Gambit, Keres Variation	rnbqkb1r/ppp2ppp/5n2/3P4/4pP2/3P4/PPPN2PP/R1BQKBNR b KQkq -	e2e4 e7e5 f2f4 d7d5 e4d5 e5e4 d2d3 g8f6 b1d2
 C32	King's Gambit, Falkbeer Countergambit, Charousek Gambit, Main Line	rn1qk2r/ppp2ppp/8/2bP1b2/4nP2/5N2/PPP1Q1PP/RNB1KB1R w KQkq -	e2e4 e7e5 f2f4 d7d5 e4d5 e5e4 d2d3 g8f6 d3e4 f6e4 g1f3 f8c5 d1e2 c8f5
 C32	King's Gambit, Falkbeer Countergambit, Charousek Gambit, Old Line	rnbqkb1r/ppp2ppp/5n2/3P4/4pP2/3P4/PPP1Q1PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 d7d5 e4d5 e5e4 d2d3 g8f6 d1e2
-C33	King's Gambit Accepted, Basman Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPQ1PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1e2
-C33	King's Gambit Accepted, Bishop's Gambit, Anderssen Defense	rnbqkbnr/pppp1p1p/8/6p1/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g7g5
+C33	King's Gambit Accepted: Basman Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPQ1PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1e2
+C33	King's Gambit Accepted: Bishop's Gambit, Anderssen Defense	rnbqkbnr/pppp1p1p/8/6p1/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g7g5
 C33	King's Gambit Accepted: Bishop's Gambit, Anderssen Variation	rnbqkbnr/pp3ppp/2p5/3B4/4Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 d7d5 c4d5 c7c6
-C33	King's Gambit Accepted, Bishop's Gambit, Bledow Countergambit	rnbqkb1r/ppp2ppp/5n2/3B4/4Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 d7d5 c4d5 g8f6
+C33	King's Gambit Accepted: Bishop's Gambit, Bledow Countergambit	rnbqkb1r/ppp2ppp/5n2/3B4/4Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 d7d5 c4d5 g8f6
 C33	King's Gambit Accepted: Bishop's Gambit, Bledow Variation	rnbqkbnr/ppp2ppp/8/3p4/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 d7d5
-C33	King's Gambit Accepted, Bishop's Gambit, Boden Variation	r1b1kbnr/pppp1ppp/2n5/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 b8c6
-C33	King's Gambit Accepted, Bishop's Gambit, Bogoljubov Defense	rnbqkb1r/pp1p1ppp/2p2n2/8/2B1Pp2/2N5/PPPP2PP/R1BQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6 b1c3 c7c6
-C33	King's Gambit Accepted, Bishop's Gambit, Bogoljubov Variation	rnbqkb1r/pppp1ppp/5n2/8/2B1Pp2/2N5/PPPP2PP/R1BQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6 b1c3
+C33	King's Gambit Accepted: Bishop's Gambit, Boden Variation	r1b1kbnr/pppp1ppp/2n5/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 b8c6
+C33	King's Gambit Accepted: Bishop's Gambit, Bogoljubov Defense	rnbqkb1r/pp1p1ppp/2p2n2/8/2B1Pp2/2N5/PPPP2PP/R1BQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6 b1c3 c7c6
+C33	King's Gambit Accepted: Bishop's Gambit, Bogoljubov Variation	rnbqkb1r/pppp1ppp/5n2/8/2B1Pp2/2N5/PPPP2PP/R1BQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6 b1c3
 C33	King's Gambit Accepted: Bishop's Gambit, Boren-Svenonius Variation	rnb1k1nr/ppp2ppp/3b4/3B4/4Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d7d5 c4d5 d8h4 e1f1 f8d6
-C33	King's Gambit Accepted, Bishop's Gambit, Bryan Countergambit	rnb1kbnr/p1pp1ppp/8/1p6/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 b7b5
+C33	King's Gambit Accepted: Bishop's Gambit, Bryan Countergambit	rnb1kbnr/p1pp1ppp/8/1p6/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 b7b5
 C33	King's Gambit Accepted: Bishop's Gambit, Chigorin's Attack	rnb1kbnr/ppp2p1p/8/3B2p1/4Pp1q/6P1/PPPP3P/RNBQ1KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 d7d5 c4d5 g7g5 g2g3
 C33	King's Gambit Accepted: Bishop's Gambit, Classical Defense: Cozio Attack	rnb1kbnr/pppp1p1p/8/6p1/2B1Pp1q/5Q2/PPPP2PP/RNB2KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 d1f3
 C33	King's Gambit Accepted: Bishop's Gambit, Classical Defense	rnb1k2r/ppppnpbp/8/6p1/2BPPp1q/2N5/PPP3PP/R1BQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g8e7 b1c3 g7g5 d2d4 f8g7
-C33	King's Gambit Accepted, Bishop's Gambit, Cozio Defense	rnbqkb1r/pppp1ppp/5n2/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6
-C33	King's Gambit Accepted, Bishop's Gambit, Cozio Variation	rnb1kbnr/ppp2ppp/3p4/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 d7d6
-C33	King's Gambit Accepted, Bishop's Gambit, First Jaenisch Variation	rnb1kb1r/pppp1ppp/5n2/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g8f6
+C33	King's Gambit Accepted: Bishop's Gambit, Cozio Defense	rnbqkb1r/pppp1ppp/5n2/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6
+C33	King's Gambit Accepted: Bishop's Gambit, Cozio Variation	rnb1kbnr/ppp2ppp/3p4/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 d7d6
+C33	King's Gambit Accepted: Bishop's Gambit, First Jaenisch Variation	rnb1kb1r/pppp1ppp/5n2/8/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g8f6
 C33	King's Gambit Accepted: Bishop's Gambit, Fraser Variation	rnb1k1nr/pppp1pbp/8/6p1/2B1P2q/2N2Qp1/PPPP3P/R1B2KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 b1c3 f8g7 g2g3 f4g3 d1f3
-C33	King's Gambit Accepted, Bishop's Gambit, Gianutio Gambit	rnbqkbnr/pppp2pp/8/5p2/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 f7f5
-C33	King's Gambit Accepted, Bishop's Gambit, Greco Variation	rnb1k1nr/pppp1ppp/8/2b5/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 f8c5
+C33	King's Gambit Accepted: Bishop's Gambit, Gianutio Gambit	rnbqkbnr/pppp2pp/8/5p2/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 f7f5
+C33	King's Gambit Accepted: Bishop's Gambit, Greco Variation	rnb1k1nr/pppp1ppp/8/2b5/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 f8c5
 C33	King's Gambit Accepted: Bishop's Gambit, Grimm Attack	rnb1k1nr/ppp2pbp/3p4/4P1p1/2BP1p1q/2N5/PPP3PP/R1BQ1KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 b1c3 f8g7 d2d4 d7d6 e4e5
-C33	King's Gambit Accepted, Bishop's Gambit, Kieseritzky Gambit	rnbqkbnr/p1pp1ppp/8/1p6/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 b7b5
-C33	King's Gambit Accepted, Bishop's Gambit, Lopez Defense	rnbqkbnr/pp1p1ppp/2p5/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 c7c6
-C33	King's Gambit Accepted, Bishop's Gambit, Lopez Variation	rnb1kbnr/pppp1p1p/8/6p1/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5
-C33	King's Gambit Accepted, Bishop's Gambit, Maurian Defense	r1bqkbnr/pppp1ppp/2n5/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 b8c6
+C33	King's Gambit Accepted: Bishop's Gambit, Kieseritzky Gambit	rnbqkbnr/p1pp1ppp/8/1p6/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 b7b5
+C33	King's Gambit Accepted: Bishop's Gambit, Lopez Defense	rnbqkbnr/pp1p1ppp/2p5/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 c7c6
+C33	King's Gambit Accepted: Bishop's Gambit, Lopez Variation	rnb1kbnr/pppp1p1p/8/6p1/2B1Pp1q/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5
+C33	King's Gambit Accepted: Bishop's Gambit, Maurian Defense	r1bqkbnr/pppp1ppp/2n5/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 b8c6
 C33	King's Gambit Accepted: Bishop's Gambit, McDonnell Attack	rnb1k1nr/pppp1pbp/8/6p1/2B1Pp1q/2N3P1/PPPP3P/R1BQ1KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 b1c3 f8g7 g2g3
-C33	King's Gambit Accepted, Bishop's Gambit, McDonnell Attack	rnb1k2r/ppppnpbp/8/6p1/2BPPp1q/2N3P1/PPP4P/R1BQ1KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 b1c3 f8g7 d2d4 g8e7 g2g3
+C33	King's Gambit Accepted: Bishop's Gambit, McDonnell Attack	rnb1k2r/ppppnpbp/8/6p1/2BPPp1q/2N3P1/PPP4P/R1BQ1KNR b kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 g7g5 b1c3 f8g7 d2d4 g8e7 g2g3
 C33	King's Gambit Accepted: Bishop's Gambit, Paulsen Attack	rnbqk2r/pppp1ppp/5n2/4P3/1bB2p2/2N5/PPPP2PP/R1BQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8f6 b1c3 f8b4 e4e5
-C33	King's Gambit Accepted, Bishop's Gambit	rnbqkbnr/pppp1ppp/8/8/2B1Pp2/8/PPPP2PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4
-C33	King's Gambit Accepted, Bishop's Gambit (see: Jaenisch Variation)	rnb1kbnr/pppp1ppp/5q2/8/2B1Pp2/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 h4f6
+C33	King's Gambit Accepted: Bishop's Gambit	rnbqkbnr/pppp1ppp/8/8/2B1Pp2/8/PPPP2PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4
+C33	King's Gambit Accepted: Bishop's Gambit (see: Jaenisch Variation)	rnb1kbnr/pppp1ppp/5q2/8/2B1Pp2/8/PPPP2PP/RNBQ1KNR w kq -	e2e4 e7e5 f2f4 e5f4 f1c4 d8h4 e1f1 h4f6
 C33	King's Gambit Accepted: Bishop's Gambit, Steinitz Defense	rnbqkb1r/ppppnppp/8/8/2B1Pp2/8/PPPP2PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1c4 g8e7
-C33	King's Gambit Accepted, Breyer Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/5Q2/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1f3
-C33	King's Gambit Accepted, Carrera Gambit	rnbqkbnr/pppp1ppp/8/7Q/4Pp2/8/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1h5
-C33	King's Gambit Accepted, Dodo Variation	rnbqkbnr/pppp1ppp/8/8/4PpQ1/8/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1g4
-C33	King's Gambit Accepted, Eisenberg Variation	rnbqkbnr/pppp1ppp/8/8/4Pp2/7N/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1h3
-C33	King's Gambit Accepted, Gaga Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/6P1/PPPP3P/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 g2g3
+C33	King's Gambit Accepted: Breyer Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/5Q2/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1f3
+C33	King's Gambit Accepted: Carrera Gambit	rnbqkbnr/pppp1ppp/8/7Q/4Pp2/8/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1h5
+C33	King's Gambit Accepted: Dodo Variation	rnbqkbnr/pppp1ppp/8/8/4PpQ1/8/PPPP2PP/RNB1KBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d1g4
+C33	King's Gambit Accepted: Eisenberg Variation	rnbqkbnr/pppp1ppp/8/8/4Pp2/7N/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1h3
+C33	King's Gambit Accepted: Gaga Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/6P1/PPPP3P/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 g2g3
 C33	King's Gambit Accepted: Lopez-Gianutio Countergambit, Hein Variation	rnbk1bnr/pppp2pp/8/8/2B1pp1q/2N5/PPPPQ1PP/R1BK2NR w - -	e2e4 e7e5 f2f4 e5f4 f1c4 f7f5 d1e2 d8h4 e1d1 f5e4 b1c3 e8d8
-C33	King's Gambit Accepted, Orsini Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/1P6/P1PP2PP/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 b2b3
-C33	King's Gambit Accepted, Paris Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPN1PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1e2
-C33	King's Gambit Accepted, Polerio Gambit	rnbqkbnr/pppp1ppp/8/8/3PPp2/8/PPP3PP/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d2d4
+C33	King's Gambit Accepted: Orsini Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/1P6/P1PP2PP/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 b2b3
+C33	King's Gambit Accepted: Paris Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPN1PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1e2
+C33	King's Gambit Accepted: Polerio Gambit	rnbqkbnr/pppp1ppp/8/8/3PPp2/8/PPP3PP/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 d2d4
 C33	King's Gambit Accepted	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP2PP/RNBQKBNR w KQkq -	e2e4 e7e5 f2f4 e5f4
-C33	King's Gambit Accepted, Schurig Gambit	rnbqkbnr/pppp1ppp/8/1B6/4Pp2/8/PPPP2PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1b5
+C33	King's Gambit Accepted: Schurig Gambit	rnbqkbnr/pppp1ppp/8/1B6/4Pp2/8/PPPP2PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1b5
 C33	King's Gambit Accepted: Schurig Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/3B4/PPPP2PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1d3
-C33	King's Gambit Accepted, Stamma Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp1P/8/PPPP2P1/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 h2h4
-C33	King's Gambit Accepted, Tartakower Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPB1PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1e2
-C33	King's Gambit Accepted, Tartakower Gambit, Weiss Defense	rnbqkbnr/ppp3pp/3p4/5P2/5p2/8/PPPPB1PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1e2 f7f5 e4f5 d7d6
-C33	King's Gambit Accepted, Tumbleweed	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP1KPP/RNBQ1BNR b kq -	e2e4 e7e5 f2f4 e5f4 e1f2
+C33	King's Gambit Accepted: Stamma Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp1P/8/PPPP2P1/RNBQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 h2h4
+C33	King's Gambit Accepted: Tartakower Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPPB1PP/RNBQK1NR b KQkq -	e2e4 e7e5 f2f4 e5f4 f1e2
+C33	King's Gambit Accepted: Tartakower Gambit, Weiss Defense	rnbqkbnr/ppp3pp/3p4/5P2/5p2/8/PPPPB1PP/RNBQK1NR w KQkq -	e2e4 e7e5 f2f4 e5f4 f1e2 f7f5 e4f5 d7d6
+C33	King's Gambit Accepted: Tumbleweed	rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP1KPP/RNBQ1BNR b kq -	e2e4 e7e5 f2f4 e5f4 e1f2
 C33	Van Geet Opening: Nowokunski Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/2N5/PPPP2PP/R1BQKBNR b KQkq -	e2e4 e7e5 f2f4 e5f4 b1c3
-C34	King's Gambit Accepted, Becker Defense	rnbqkbnr/pppp1pp1/7p/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 h7h6
-C34	King's Gambit Accepted, Bonsch-Osmolovsky Variation	rnbqkb1r/ppppnppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g8e7
-C34	King's Gambit Accepted, Fischer Defense	rnbqkbnr/ppp2ppp/3p4/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6
-C34	King's Gambit Accepted, Fischer Defense, Schulder Gambit	rnbqkbnr/ppp2ppp/3p4/8/1P2Pp2/5N2/P1PP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 b2b4
-C34	King's Gambit Accepted, Fischer Defense, Spanish Variation	rnbqkb1r/ppp2ppp/3p1n2/8/3PPp2/3B1N2/PPP3PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 d2d4 g8f6 f1d3
-C34	King's Gambit Accepted, Gianutio Countergambit	rnbqkbnr/pppp2pp/8/5p2/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f7f5
-C34	King's Gambit Accepted, Greco Gambit	rnbqk1nr/ppp2pb1/3p3p/6p1/2BPPp1P/5N2/PPP3P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 f1c4 h7h6 d2d4 g7g5 h2h4 f8g7
+C34	King's Gambit Accepted: Becker Defense	rnbqkbnr/pppp1pp1/7p/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 h7h6
+C34	King's Gambit Accepted: Bonsch-Osmolovsky Variation	rnbqkb1r/ppppnppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g8e7
+C34	King's Gambit Accepted: Fischer Defense	rnbqkbnr/ppp2ppp/3p4/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6
+C34	King's Gambit Accepted: Fischer Defense, Schulder Gambit	rnbqkbnr/ppp2ppp/3p4/8/1P2Pp2/5N2/P1PP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 b2b4
+C34	King's Gambit Accepted: Fischer Defense, Spanish Variation	rnbqkb1r/ppp2ppp/3p1n2/8/3PPp2/3B1N2/PPP3PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 d2d4 g8f6 f1d3
+C34	King's Gambit Accepted: Gianutio Countergambit	rnbqkbnr/pppp2pp/8/5p2/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f7f5
+C34	King's Gambit Accepted: Greco Gambit	rnbqk1nr/ppp2pb1/3p3p/6p1/2BPPp1P/5N2/PPP3P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d6 f1c4 h7h6 d2d4 g7g5 h2h4 f8g7
 C34	King's Gambit Accepted: King Knight's Gambit	rnbqkbnr/pppp1p1p/8/6p1/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5
-C34	King's Gambit Accepted, King's Knight Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3
-C34	King's Gambit Accepted, MacLeod Defense	r1bqkbnr/pppp1ppp/2n5/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 b8c6
-C34	King's Gambit Accepted, Schallopp Defense	rnbqkb1r/pppp1ppp/5n2/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g8f6
-C34	King's Gambit Accepted, Schallopp Defense, Tashkent Attack	rnbqkb1r/pppp1ppp/8/4P2n/5pP1/5N2/PPPP3P/RNBQKB1R b KQkq g3	e2e4 e7e5 f2f4 e5f4 g1f3 g8f6 e4e5 f6h5 g2g4
+C34	King's Gambit Accepted: King's Knight Gambit	rnbqkbnr/pppp1ppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3
+C34	King's Gambit Accepted: MacLeod Defense	r1bqkbnr/pppp1ppp/2n5/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 b8c6
+C34	King's Gambit Accepted: Schallopp Defense	rnbqkb1r/pppp1ppp/5n2/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g8f6
+C34	King's Gambit Accepted: Schallopp Defense, Tashkent Attack	rnbqkb1r/pppp1ppp/8/4P2n/5pP1/5N2/PPPP3P/RNBQKB1R b KQkq g3	e2e4 e7e5 f2f4 e5f4 g1f3 g8f6 e4e5 f6h5 g2g4
 C35	King's Gambit Accepted: Cunningham, Bertin Gambit	rnbqk1nr/pppp1ppp/8/8/2B1Pp1b/5NP1/PPPP3P/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7 f1c4 e7h4 g2g3
-C35	King's Gambit Accepted, Cunningham Defense, Bertin Gambit	rnbqk1nr/pppp1ppp/8/8/2B1P2b/5N2/PPPP3p/RNBQ1R1K b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7 f1c4 e7h4 g2g3 f4g3 e1g1 g3h2 g1h1
-C35	King's Gambit Accepted, Cunningham Defense, McCormick Defense	rnbqk2r/ppppbppp/5n2/8/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7 f1c4 g8f6
-C35	King's Gambit Accepted, Cunningham Defense	rnbqk1nr/ppppbppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7
-C36	King's Gambit Accepted, Abbazia Defense, Main Line	rnbqkb1r/p4ppp/2p5/3n4/2B2p2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5 e4d5 g8f6 f1b5 c7c6 d5c6 b7c6 b5c4 f6d5
-C36	King's Gambit Accepted, Abbazia Defense	rnbqkb1r/ppp2ppp/5n2/3P4/5p2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5 e4d5 g8f6
-C36	King's Gambit Accepted, Modern Defense	rnbqkbnr/ppp2ppp/8/3p4/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5
+C35	King's Gambit Accepted: Cunningham Defense, Bertin Gambit	rnbqk1nr/pppp1ppp/8/8/2B1P2b/5N2/PPPP3p/RNBQ1R1K b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7 f1c4 e7h4 g2g3 f4g3 e1g1 g3h2 g1h1
+C35	King's Gambit Accepted: Cunningham Defense, McCormick Defense	rnbqk2r/ppppbppp/5n2/8/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7 f1c4 g8f6
+C35	King's Gambit Accepted: Cunningham Defense	rnbqk1nr/ppppbppp/8/8/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 f8e7
+C36	King's Gambit Accepted: Abbazia Defense, Main Line	rnbqkb1r/p4ppp/2p5/3n4/2B2p2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5 e4d5 g8f6 f1b5 c7c6 d5c6 b7c6 b5c4 f6d5
+C36	King's Gambit Accepted: Abbazia Defense	rnbqkb1r/ppp2ppp/5n2/3P4/5p2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5 e4d5 g8f6
+C36	King's Gambit Accepted: Modern Defense	rnbqkbnr/ppp2ppp/8/3p4/4Pp2/5N2/PPPP2PP/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5
 C36	King's Gambit Accepted: Modern Defense	rnbqkbnr/ppp2ppp/8/3P4/5p2/5N2/PPPP2PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 d7d5 e4d5
-C37	King's Gambit Accepted, Australian Gambit	rnbqkbnr/pppp1p1p/8/8/2B1PppP/5N2/PPPP2P1/RNBQK2R b KQkq h3	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 h2h4
-C37	King's Gambit Accepted, Blachly Gambit	r1bqkbnr/pppp1p1p/2n5/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 b8c6 f1c4 g7g5
-C37	King's Gambit Accepted, Double Muzio Gambit, Baldwin Gambit	rnb1kbnr/pppp1p1p/8/3N4/2q1Pp2/5Q2/PPPP2PP/R1B2R1K b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 b1c3 f6d4 g1h1 d4c4 c3d5
-C37	King's Gambit Accepted, Double Muzio Gambit, Bello Gambit	rnb1kbnr/pppp1p1p/5q2/8/2B1Pp2/2N2Q2/PPPP2PP/R1B2RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 b1c3
-C37	King's Gambit Accepted, Double Muzio Gambit, Paulsen Defense	r1b1k2r/ppppnp1p/2n4b/4q3/2B2p2/2NP1Q2/PPPB2PP/4RRK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 e4e5 f6e5 d2d3 f8h6 b1c3 g8e7 c1d2 b8c6 a1e1
-C37	King's Gambit Accepted, Double Muzio Gambit	rnb1kbnr/pppp1B1p/8/4q3/5p2/5Q2/PPPP2PP/RNB2RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 e4e5 f6e5 c4f7
-C37	King's Gambit Accepted, Double Muzio Gambit, Young Gambit	rnb2bnr/pppp1k1p/5q2/8/4P3/2N1pQ2/PPP3PP/R4RK1 w - -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 c4f7 e8f7 d2d4 f6d4 c1e3 d4f6 b1c3 f4e3
-C37	King's Gambit Accepted, Ghulam-Kassim Gambit	rnbqkbnr/pppp1p1p/8/8/2BPPp2/5Q2/PPP3PP/RNB1K2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 d2d4 g4f3 d1f3
+C37	King's Gambit Accepted: Australian Gambit	rnbqkbnr/pppp1p1p/8/8/2B1PppP/5N2/PPPP2P1/RNBQK2R b KQkq h3	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 h2h4
+C37	King's Gambit Accepted: Blachly Gambit	r1bqkbnr/pppp1p1p/2n5/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 b8c6 f1c4 g7g5
+C37	King's Gambit Accepted: Double Muzio Gambit, Baldwin Gambit	rnb1kbnr/pppp1p1p/8/3N4/2q1Pp2/5Q2/PPPP2PP/R1B2R1K b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 b1c3 f6d4 g1h1 d4c4 c3d5
+C37	King's Gambit Accepted: Double Muzio Gambit, Bello Gambit	rnb1kbnr/pppp1p1p/5q2/8/2B1Pp2/2N2Q2/PPPP2PP/R1B2RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 b1c3
+C37	King's Gambit Accepted: Double Muzio Gambit, Paulsen Defense	r1b1k2r/ppppnp1p/2n4b/4q3/2B2p2/2NP1Q2/PPPB2PP/4RRK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 e4e5 f6e5 d2d3 f8h6 b1c3 g8e7 c1d2 b8c6 a1e1
+C37	King's Gambit Accepted: Double Muzio Gambit	rnb1kbnr/pppp1B1p/8/4q3/5p2/5Q2/PPPP2PP/RNB2RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 e4e5 f6e5 c4f7
+C37	King's Gambit Accepted: Double Muzio Gambit, Young Gambit	rnb2bnr/pppp1k1p/5q2/8/4P3/2N1pQ2/PPP3PP/R4RK1 w - -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6 c4f7 e8f7 d2d4 f6d4 c1e3 d4f6 b1c3 f4e3
+C37	King's Gambit Accepted: Ghulam-Kassim Gambit	rnbqkbnr/pppp1p1p/8/8/2BPPp2/5Q2/PPP3PP/RNB1K2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 d2d4 g4f3 d1f3
 C37	King's Gambit Accepted: Ghulam-Kassim Gambit	rnbqkbnr/pppp1p1p/8/8/2BPPpp1/5N2/PPP3PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 d2d4
-C37	King's Gambit Accepted, King's Knight Gambit	rnbqkbnr/pppp1p1p/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4
-C37	King's Gambit Accepted, Kotov Gambit	rnbqkbnr/pppp1p1p/8/8/2BPPB2/5p2/PPP3PP/RN1QK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 d2d4 g4f3 c1f4
-C37	King's Gambit Accepted, Lolli Gambit	rnbqkbnr/pppp1B1p/8/8/4Ppp1/5N2/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 c4f7
+C37	King's Gambit Accepted: King's Knight Gambit	rnbqkbnr/pppp1p1p/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4
+C37	King's Gambit Accepted: Kotov Gambit	rnbqkbnr/pppp1p1p/8/8/2BPPB2/5p2/PPP3PP/RN1QK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 d2d4 g4f3 c1f4
+C37	King's Gambit Accepted: Lolli Gambit	rnbqkbnr/pppp1B1p/8/8/4Ppp1/5N2/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 c4f7
 C37	King's Gambit Accepted: Lolli Gambit, Young Variation	rnb2bnr/pppp1k1p/5q2/8/4Pp2/2N1BQ2/PPP3PP/R4RK1 b - -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 c4f7 e8f7 e1g1 g4f3 d1f3 d8f6 d2d4 f6d4 c1e3 d4f6 b1c3
-C37	King's Gambit Accepted, McDonnell Gambit	rnbqkbnr/pppp1p1p/8/8/2B1Ppp1/2N2N2/PPPP2PP/R1BQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 b1c3
-C37	King's Gambit Accepted, Middleton Countergambit	rn1qkbnr/ppp2p2/3p4/6p1/2B1Ppp1/5N2/PPPP2P1/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 d7d6 e1g1 c8g4 h2h3 h7h5 h3g4 h5g4
-C37	King's Gambit Accepted, Muzio Gambit Accepted, From's Defense	rnb1kbnr/ppppqp1p/8/8/2B1Pp2/5Q2/PPPP2PP/RNB2RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8e7
-C37	King's Gambit Accepted, Muzio Gambit, Brentano Defense	rnbqkbnr/ppp2p1p/8/3p4/2B1Ppp1/5N2/PPPP2PP/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 d7d5
+C37	King's Gambit Accepted: McDonnell Gambit	rnbqkbnr/pppp1p1p/8/8/2B1Ppp1/2N2N2/PPPP2PP/R1BQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 b1c3
+C37	King's Gambit Accepted: Middleton Countergambit	rn1qkbnr/ppp2p2/3p4/6p1/2B1Ppp1/5N2/PPPP2P1/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 d7d6 e1g1 c8g4 h2h3 h7h5 h3g4 h5g4
+C37	King's Gambit Accepted: Muzio Gambit Accepted, From's Defense	rnb1kbnr/ppppqp1p/8/8/2B1Pp2/5Q2/PPPP2PP/RNB2RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8e7
+C37	King's Gambit Accepted: Muzio Gambit, Brentano Defense	rnbqkbnr/ppp2p1p/8/3p4/2B1Ppp1/5N2/PPPP2PP/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 d7d5
 C37	King's Gambit Accepted: Muzio Gambit, Holloway Defense	r1bqkbnr/pppp1p1p/2n5/8/2B1Pp2/5Q2/PPPP2PP/RNB2RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 b8c6
 C37	King's Gambit Accepted: Muzio Gambit, Kling and Horwitz Counterattack	rnb1kbnr/ppppqp1p/8/8/2B1Ppp1/5N2/PPPP2PP/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 d8e7
-C37	King's Gambit Accepted, Muzio Gambit, Sarratt Defense	rnb1kbnr/pppp1p1p/5q2/8/2B1Pp2/5Q2/PPPP2PP/RNB2RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6
-C37	King's Gambit Accepted, Muzio Gambit, Wild Muzio Gambit	rnbqkbnr/pppp1p1p/8/8/2B1Ppp1/5N2/PPPP2PP/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1
-C37	King's Gambit Accepted, Quade Gambit	rnbqkbnr/pppp1p1p/8/6p1/4Pp2/2N2N2/PPPP2PP/R1BQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 b1c3
-C37	King's Gambit Accepted, Rosentreter Gambit, Bird Gambit	rnb1kbnr/pppp1p1p/8/4N3/3PPppq/6P1/PPP4P/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 f3e5 d8h4 g2g3
-C37	King's Gambit Accepted, Rosentreter Gambit	rnbqkbnr/pppp1p1p/8/6p1/3PPp2/5N2/PPP3PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4
-C37	King's Gambit Accepted, Rosentreter Gambit, Sörensen Gambit	rnbqkbnr/pppp1p1p/8/8/3PPpp1/2N2N2/PPP3PP/R1BQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 b1c3
-C37	King's Gambit Accepted, Rosentreter-Testa Gambit	rnbqkbnr/pppp1p1p/8/8/3PPBp1/5N2/PPP3PP/RN1QKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 c1f4
+C37	King's Gambit Accepted: Muzio Gambit, Sarratt Defense	rnb1kbnr/pppp1p1p/5q2/8/2B1Pp2/5Q2/PPPP2PP/RNB2RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1 g4f3 d1f3 d8f6
+C37	King's Gambit Accepted: Muzio Gambit, Wild Muzio Gambit	rnbqkbnr/pppp1p1p/8/8/2B1Ppp1/5N2/PPPP2PP/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 e1g1
+C37	King's Gambit Accepted: Quade Gambit	rnbqkbnr/pppp1p1p/8/6p1/4Pp2/2N2N2/PPPP2PP/R1BQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 b1c3
+C37	King's Gambit Accepted: Rosentreter Gambit, Bird Gambit	rnb1kbnr/pppp1p1p/8/4N3/3PPppq/6P1/PPP4P/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 f3e5 d8h4 g2g3
+C37	King's Gambit Accepted: Rosentreter Gambit	rnbqkbnr/pppp1p1p/8/6p1/3PPp2/5N2/PPP3PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4
+C37	King's Gambit Accepted: Rosentreter Gambit, Sörensen Gambit	rnbqkbnr/pppp1p1p/8/8/3PPpp1/2N2N2/PPP3PP/R1BQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 b1c3
+C37	King's Gambit Accepted: Rosentreter-Testa Gambit	rnbqkbnr/pppp1p1p/8/8/3PPBp1/5N2/PPP3PP/RN1QKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 c1f4
 C37	King's Gambit Accepted: Salvio Gambit, Anderssen Counterattack	rnb1kb1r/ppp2p1p/3p3n/4N3/2BPPppq/8/PPP3PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8h6 d2d4 d7d6
-C37	King's Gambit Accepted, Salvio Gambit, Cochrane Gambit	rnb1kbnr/pppp1p1p/8/4N3/2B1P1pq/5p2/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 f4f3
-C37	King's Gambit Accepted, Salvio Gambit	rnbqkbnr/pppp1p1p/8/4N3/2B1Ppp1/8/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5
-C37	King's Gambit Accepted, Salvio Gambit, Santa Maria Defense	rnb1kb1r/pppp1p1p/5n2/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8f6
-C37	King's Gambit Accepted, Salvio Gambit, Silberschmidt Defense	rnb1kb1r/pppp1p1p/7n/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8h6
-C37	King's Gambit Accepted, Salvio Gambit, Viennese Variation	r1b1kbnr/pppp1p1p/2n5/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 b8c6
+C37	King's Gambit Accepted: Salvio Gambit, Cochrane Gambit	rnb1kbnr/pppp1p1p/8/4N3/2B1P1pq/5p2/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 f4f3
+C37	King's Gambit Accepted: Salvio Gambit	rnbqkbnr/pppp1p1p/8/4N3/2B1Ppp1/8/PPPP2PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5
+C37	King's Gambit Accepted: Salvio Gambit, Santa Maria Defense	rnb1kb1r/pppp1p1p/5n2/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8f6
+C37	King's Gambit Accepted: Salvio Gambit, Silberschmidt Defense	rnb1kb1r/pppp1p1p/7n/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8h6
+C37	King's Gambit Accepted: Salvio Gambit, Viennese Variation	r1b1kbnr/pppp1p1p/2n5/4N3/2B1Pppq/8/PPPP2PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 b8c6
 C37	King's Gambit Accepted: Silberschmidt Gambit	rnb1kb1r/pppp1p1p/7n/4N3/2BPP1pq/5p2/PPP3PP/RNBQ1K1R w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 g5g4 f3e5 d8h4 e1f1 g8h6 d2d4 f4f3
 C37	King's Gambit Accepted: Sörensen Gambit	rnbqkbnr/pppp1p1p/8/4N3/3PPpp1/8/PPP3PP/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 d2d4 g5g4 f3e5
 C38	King's Gambit Accepted: Greco Gambit	rnbqk1nb/pp3p2/2pp4/4N1p1/2BPPp2/2N5/PPP3P1/R1BQK3 b Qq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 h2h4 h7h6 d2d4 d7d6 b1c3 c7c6 h4g5 h6g5 h1h8 g7h8 f3e5
-C38	King's Gambit Accepted, Hanstein Gambit	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 e1g1
-C38	King's Gambit Accepted, Mayet Gambit	rnbqk1nr/ppp2pbp/3p4/6p1/2BPPp2/2P2N2/PP4PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 d2d4 d7d6 c2c3
-C38	King's Gambit Accepted, Philidor Gambit	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp1P/5N2/PPPP2P1/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 h2h4
-C38	King's Gambit Accepted, Philidor Gambit, Schultz Variation	rnbqk1nr/ppp2pb1/3p3p/6p1/2BPPp1P/3Q1N2/PPP3P1/RNB1K2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 h7h6 f1c4 d7d6 d2d4 g7g5 h2h4 f8g7 d1d3
-C38	King's Gambit Accepted, Traditional Variation	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7
+C38	King's Gambit Accepted: Hanstein Gambit	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 e1g1
+C38	King's Gambit Accepted: Mayet Gambit	rnbqk1nr/ppp2pbp/3p4/6p1/2BPPp2/2P2N2/PP4PP/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 d2d4 d7d6 c2c3
+C38	King's Gambit Accepted: Philidor Gambit	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp1P/5N2/PPPP2P1/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7 h2h4
+C38	King's Gambit Accepted: Philidor Gambit, Schultz Variation	rnbqk1nr/ppp2pb1/3p3p/6p1/2BPPp1P/3Q1N2/PPP3P1/RNB1K2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 h7h6 f1c4 d7d6 d2d4 g7g5 h2h4 f8g7 d1d3
+C38	King's Gambit Accepted: Traditional Variation	rnbqk1nr/pppp1pbp/8/6p1/2B1Pp2/5N2/PPPP2PP/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 f1c4 f8g7
 C39	King's Gambit Accepted: Allgaier, Blackburne Gambit	rnbq1bnr/pppp1k2/7p/8/4PppP/2N5/PPPP2P1/R1BQKB1R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 b1c3
 C39	King's Gambit Accepted: Allgaier, Cook Variation	rnbq1bnr/ppp3k1/7p/4B3/2BPp1pP/8/PPP3P1/RN1QK2R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 d2d4 d7d5 c1f4 d5e4 f1c4 f7g7 f4e5
-C39	King's Gambit Accepted, Allgaier Gambit	rnbqkbnr/pppp1p1p/8/6N1/4PppP/8/PPPP2P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5
-C39	King's Gambit Accepted, Allgaier Gambit, Thorold Attack	rnbq1bnr/pppp1k2/7p/8/3PPppP/8/PPP3P1/RNBQKB1R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 d2d4
-C39	King's Gambit Accepted, Allgaier Gambit, Urusov Attack	rnbq1bnr/pppp1k2/7p/8/2B1PppP/8/PPPP2P1/RNBQK2R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 f1c4
+C39	King's Gambit Accepted: Allgaier Gambit	rnbqkbnr/pppp1p1p/8/6N1/4PppP/8/PPPP2P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5
+C39	King's Gambit Accepted: Allgaier Gambit, Thorold Attack	rnbq1bnr/pppp1k2/7p/8/3PPppP/8/PPP3P1/RNBQKB1R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 d2d4
+C39	King's Gambit Accepted: Allgaier Gambit, Urusov Attack	rnbq1bnr/pppp1k2/7p/8/2B1PppP/8/PPPP2P1/RNBQK2R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 f1c4
 C39	King's Gambit Accepted: Allgaier, Horny Defense	rnbq3r/pppp1k2/3b1n1p/8/4PQ1P/8/PPPP2P1/RNB1KB1R w KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 d1g4 g8f6 g4f4 f8d6
 C39	King's Gambit Accepted: Allgaier, Schlechter Defense	rnbqkb1r/pppp1p1p/5n2/6N1/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 g8f6
 C39	King's Gambit Accepted: Allgaier, Urusov Attack	rnbq1bnr/ppp3k1/7p/3B4/3PPppP/8/PPP3P1/RNBQK2R b KQ -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7 e8f7 f1c4 d7d5 c4d5 f7g7 d2d4
@@ -496,20 +496,20 @@ C39	King's Gambit Accepted: Kieseritzky, Berlin Defense: de Riviere Variation	rn
 C39	King's Gambit Accepted: Kieseritzky, Brentano Defense: Caro Variation	rnbqkb1r/ppp2p1p/8/3pN3/3PnBpP/8/PPPN2P1/R2QKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5 d2d4 g8f6 c1f4 f6e4 b1d2
 C39	King's Gambit Accepted: Kieseritzky, Brentano Defense: Kaplanek Variation	rnb1k2r/ppp2p1p/5n2/3qN3/1b1P1ppP/2N5/PPP2KP1/R1BQ1B1R b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5 d2d4 g8f6 e4d5 d8d5 b1c3 f8b4 e1f2
 C39	King's Gambit Accepted: Kieseritzky, Brentano Defense	rnbqkb1r/ppp2p1p/5n2/3pN3/3PPBpP/8/PPP3P1/RN1QKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5 d2d4 g8f6 c1f4
-C39	King's Gambit Accepted, Kieseritzky Gambit, Anderssen-Cordel Gambit	rnbqk2r/ppp2p1p/3b4/3PN3/2BP1npP/8/PPP3P1/RN1QK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 d2d4 f6h5 c1f4 h5f4
-C39	King's Gambit Accepted, Kieseritzky Gambit, Anderssen Defense	rnbqk2r/ppp2p1p/3b1n2/3PN3/2B2ppP/8/PPPP2P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6
-C39	King's Gambit Accepted, Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/2B1PppP/8/PPPP2P1/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4
-C39	King's Gambit Accepted, Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6
-C39	King's Gambit Accepted, Kieseritzky Gambit, Brentano Defense	rnbqkbnr/ppp2p1p/8/3pN3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5
-C39	King's Gambit Accepted, Kieseritzky Gambit, Cotter Gambit	rnbqkbnr/pppp1N2/7p/8/4PppP/8/PPPP2P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7
-C39	King's Gambit Accepted, Kieseritzky Gambit, Kolisch Defense	rnbqkbnr/ppp2p1p/3p4/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d6
-C39	King's Gambit Accepted, Kieseritzky Gambit, Long Whip	rnbqkbnr/pppp1p2/8/4N2p/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 h7h5
-C39	King's Gambit Accepted, Kieseritzky Gambit, Neumann Defense	r1bqkbnr/pppp1p1p/2n5/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 b8c6
-C39	King's Gambit Accepted, Kieseritzky Gambit, Paulsen Defense Deferred	rnbqk2r/ppp2pbp/5n2/3PN3/2B2ppP/8/PPPP2P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8g7
-C39	King's Gambit Accepted, Kieseritzky Gambit, Paulsen Defense	rnbqk1nr/pppp1pbp/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 f8g7
-C39	King's Gambit Accepted, Kieseritzky Gambit, Rice Gambit	rnbqk2r/ppp2p1p/5n2/3Pb3/2B2ppP/8/PPPP2P1/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 e1g1 d6e5
-C39	King's Gambit Accepted, Kieseritzky Gambit, Rosenthal Defense	rnb1kbnr/ppppqp1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d8e7
-C39	King's Gambit Accepted, Kieseritzky Gambit, Rubinstein Variation	rnbqkb1r/pppp1p1p/5n2/4N3/3PPppP/8/PPP3P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 d2d4
+C39	King's Gambit Accepted: Kieseritzky Gambit, Anderssen-Cordel Gambit	rnbqk2r/ppp2p1p/3b4/3PN3/2BP1npP/8/PPP3P1/RN1QK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 d2d4 f6h5 c1f4 h5f4
+C39	King's Gambit Accepted: Kieseritzky Gambit, Anderssen Defense	rnbqk2r/ppp2p1p/3b1n2/3PN3/2B2ppP/8/PPPP2P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6
+C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/2B1PppP/8/PPPP2P1/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4
+C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6
+C39	King's Gambit Accepted: Kieseritzky Gambit, Brentano Defense	rnbqkbnr/ppp2p1p/8/3pN3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5
+C39	King's Gambit Accepted: Kieseritzky Gambit, Cotter Gambit	rnbqkbnr/pppp1N2/7p/8/4PppP/8/PPPP2P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3g5 h7h6 g5f7
+C39	King's Gambit Accepted: Kieseritzky Gambit, Kolisch Defense	rnbqkbnr/ppp2p1p/3p4/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d6
+C39	King's Gambit Accepted: Kieseritzky Gambit, Long Whip	rnbqkbnr/pppp1p2/8/4N2p/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 h7h5
+C39	King's Gambit Accepted: Kieseritzky Gambit, Neumann Defense	r1bqkbnr/pppp1p1p/2n5/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 b8c6
+C39	King's Gambit Accepted: Kieseritzky Gambit, Paulsen Defense Deferred	rnbqk2r/ppp2pbp/5n2/3PN3/2B2ppP/8/PPPP2P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8g7
+C39	King's Gambit Accepted: Kieseritzky Gambit, Paulsen Defense	rnbqk1nr/pppp1pbp/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 f8g7
+C39	King's Gambit Accepted: Kieseritzky Gambit, Rice Gambit	rnbqk2r/ppp2p1p/5n2/3Pb3/2B2ppP/8/PPPP2P1/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 e1g1 d6e5
+C39	King's Gambit Accepted: Kieseritzky Gambit, Rosenthal Defense	rnb1kbnr/ppppqp1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d8e7
+C39	King's Gambit Accepted: Kieseritzky Gambit, Rubinstein Variation	rnbqkb1r/pppp1p1p/5n2/4N3/3PPppP/8/PPP3P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 d2d4
 C39	King's Gambit Accepted: Kieseritzky, Long Whip Defense: Jaenisch Variation	rnbqk1n1/pppp1p1r/7b/4N2p/2BPPppP/2N5/PPP3P1/R1BQK2R b KQq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 h7h5 f1c4 h8h7 d2d4 f8h6 b1c3
 C39	King's Gambit Accepted: Kieseritzky, Polerio Defense	rnbqk1nr/ppppbp1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 f8e7
 C39	King's Gambit Accepted: Kieseritzky, Rice Gambit	rnbqk2r/ppp2p1p/3b1n2/3PN3/2B2ppP/8/PPPP2P1/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 e1g1
@@ -530,14 +530,14 @@ C40	King's Pawn Game: Gunderam Defense, Gunderam Gambit	rnb1kbnr/ppppq1pp/8/4pp2
 C40	King's Pawn Game: Gunderam Gambit	rnbqkbnr/pp1p1ppp/2p5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq -	e2e4 e7e5 g1f3 c7c6
 C40	King's Pawn Game: La Bourdonnais Gambit	rnb1kbnr/pppp1ppp/6q1/4p3/2B1P3/5N2/PPPP1PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 d8f6 f1c4 f6g6 e1g1
 C40	King's Pawn Game: McConnell Defense	rnb1kbnr/pppp1ppp/5q2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq -	e2e4 e7e5 g1f3 d8f6
-C40	Latvian Gambit Accepted, Bilguer Variation	rnb1kbnr/ppp3pp/3p1q2/5p2/2NPP3/8/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4
-C40	Latvian Gambit Accepted, Bronstein Attack	rnb1kbnr/ppp3pp/3p1q2/8/2NPp3/8/PPP1BPPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 f1e2
-C40	Latvian Gambit Accepted, Bronstein Gambit	rnb1kbnr/ppp4p/3p1qp1/8/2NPp3/8/PPP1QPPP/RNB1KB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 d1h5 g7g6 h5e2
-C40	Latvian Gambit Accepted, Foltys-Leonhardt Variation	rnb1kbnr/pppp2pp/5q2/5p2/2N1P3/8/PPPP1PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4
-C40	Latvian Gambit Accepted, Foltys Variation	rnb1kbnr/pppp2pp/5q2/8/2N1p3/3P4/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4 f5e4 d2d3
-C40	Latvian Gambit Accepted, Leonhardt Variation	rnb1kbnr/pppp2pp/5q2/8/2N1p3/2N5/PPPP1PPP/R1BQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4 f5e4 b1c3
-C40	Latvian Gambit Accepted, Main Line	rnb1kbnr/pppp2pp/5q2/4Np2/3PP3/8/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4
-C40	Latvian Gambit Accepted, Nimzowitsch Attack	rnb1kbnr/ppp3pp/3p1q2/8/3Pp3/4N3/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 c4e3
+C40	Latvian Gambit Accepted: Bilguer Variation	rnb1kbnr/ppp3pp/3p1q2/5p2/2NPP3/8/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4
+C40	Latvian Gambit Accepted: Bronstein Attack	rnb1kbnr/ppp3pp/3p1q2/8/2NPp3/8/PPP1BPPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 f1e2
+C40	Latvian Gambit Accepted: Bronstein Gambit	rnb1kbnr/ppp4p/3p1qp1/8/2NPp3/8/PPP1QPPP/RNB1KB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 d1h5 g7g6 h5e2
+C40	Latvian Gambit Accepted: Foltys-Leonhardt Variation	rnb1kbnr/pppp2pp/5q2/5p2/2N1P3/8/PPPP1PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4
+C40	Latvian Gambit Accepted: Foltys Variation	rnb1kbnr/pppp2pp/5q2/8/2N1p3/3P4/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4 f5e4 d2d3
+C40	Latvian Gambit Accepted: Leonhardt Variation	rnb1kbnr/pppp2pp/5q2/8/2N1p3/2N5/PPPP1PPP/R1BQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 e5c4 f5e4 b1c3
+C40	Latvian Gambit Accepted: Main Line	rnb1kbnr/pppp2pp/5q2/4Np2/3PP3/8/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4
+C40	Latvian Gambit Accepted: Nimzowitsch Attack	rnb1kbnr/ppp3pp/3p1q2/8/3Pp3/4N3/PPP2PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 f3e5 d8f6 d2d4 d7d6 e5c4 f5e4 c4e3
 C40	Latvian Gambit Accepted	rnbqkbnr/pppp2pp/8/4pP2/8/5N2/PPPP1PPP/RNBQKB1R b KQkq -	e2e4 e7e5 g1f3 f7f5 e4f5
 C40	Latvian Gambit: Behting Variation	rnb1kb1N/ppp3pp/5n2/3p4/2B1p3/8/PPPP1PqP/RNBQKR2 w Qq -	e2e4 e7e5 g1f3 f7f5 f1c4 f5e4 f3e5 d8g5 e5f7 g5g2 h1f1 d7d5 f7h8 g8f6
 C40	Latvian Gambit: Corkscrew Countergambit	rnbqkb1r/pppp2pp/5n2/4N3/2B1p3/8/PPPP1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 f7f5 f1c4 f5e4 f3e5 g8f6
@@ -962,7 +962,7 @@ C60	Ruy Lopez: Vinogradov Variation	r1b1kbnr/ppppqppp/2n5/1B2p3/4P3/5N2/PPPP1PPP
 C60	Spanish Opening: Fianchetto Defense, Kevitz Gambit	r1bqkbnr/pppp3p/2n3p1/1B2pp2/4P3/2P2N2/PP1P1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g7g6 c2c3 f7f5
 C61	Ruy Lopez: Bird Variation, Paulsen Variation	r1bqkb1r/ppppnppp/8/1B6/3pP3/8/PPPP1PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 c6d4 f3d4 e5d4 e1g1 g8e7
 C61	Ruy Lopez: Bird Variation	r1bqkbnr/pppp1ppp/8/1B2p3/3nP3/5N2/PPPP1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 c6d4
-C62	Ruy Lopez: Old Steinitz Defense: Semi-Duras Variation	r2qkbnr/pppb1ppp/2np4/1B2p3/2PPP3/5N2/PP3PPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6 d2d4 c8d7 c2c4
+C62	Ruy Lopez: Old Steinitz Defense, Semi-Duras Variation	r2qkbnr/pppb1ppp/2np4/1B2p3/2PPP3/5N2/PP3PPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6 d2d4 c8d7 c2c4
 C62	Ruy Lopez: Steinitz Defense, Center Gambit	r1bqkbnr/ppp2ppp/2np4/1B6/3pP3/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6 d2d4 e5d4 e1g1
 C62	Ruy Lopez: Steinitz Defense, Nimzowitsch Attack	r2qkb1r/pppb1ppp/2Bp1n2/4p3/3PP3/2N2N2/PPP2PPP/R1BQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6 d2d4 c8d7 b1c3 g8f6 b5c6
 C62	Ruy Lopez: Steinitz Defense	r1bqkbnr/ppp2ppp/2np4/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6
@@ -975,9 +975,9 @@ C63	Ruy Lopez: Schliemann Defense, Möhring Variation	r1b1kbnr/ppp3pp/2N5/1B1q4/
 C63	Ruy Lopez: Schliemann Defense	r1bqkbnr/pppp2pp/2n5/1B2pp2/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f7f5
 C63	Ruy Lopez: Schliemann Defense, Schönemann Attack	r1bqkbnr/pppp2pp/2n5/1B2pp2/3PP3/5N2/PPP2PPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f7f5 d2d4
 C63	Ruy Lopez: Schliemann Defense, Tartakower Variation	r1bqkb1r/pppp2pp/2n2n2/1B2p3/4N3/5N2/PPPP1PPP/R1BQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f7f5 b1c3 f5e4 c3e4 g8f6
-C64	Ruy Lopez: Classical Defense: Benelux Variation	r1bq1rk1/pppp1ppp/1bn2n2/1B2p3/3PP3/2P2N2/PP3PPP/RNBQ1RK1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f8c5 c2c3 e8g8 d2d4 c5b6
-C64	Ruy Lopez: Classical Defense: Boden Variation	r1b1k1nr/ppppqppp/2n5/1Bb1p3/4P3/2P2N2/PP1P1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 c2c3 d8e7
-C64	Ruy Lopez: Classical Defense: Zaitsev Variation	r1bqk1nr/pppp1ppp/8/1Bb1p3/1P1nP3/5N2/P1PP1PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 e1g1 c6d4 b2b4
+C64	Ruy Lopez: Classical Defense, Benelux Variation	r1bq1rk1/pppp1ppp/1bn2n2/1B2p3/3PP3/2P2N2/PP3PPP/RNBQ1RK1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f8c5 c2c3 e8g8 d2d4 c5b6
+C64	Ruy Lopez: Classical Defense, Boden Variation	r1b1k1nr/ppppqppp/2n5/1Bb1p3/4P3/2P2N2/PP1P1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 c2c3 d8e7
+C64	Ruy Lopez: Classical Defense, Zaitsev Variation	r1bqk1nr/pppp1ppp/8/1Bb1p3/1P1nP3/5N2/P1PP1PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 e1g1 c6d4 b2b4
 C64	Ruy Lopez: Classical Variation, Central Variation	r1bqk1nr/pppp1ppp/2n5/1Bb1p3/4P3/2P2N2/PP1P1PPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 c2c3
 C64	Ruy Lopez: Classical Variation, Charousek Variation	r1bqk1nr/pppp1ppp/1bn5/1B2p3/4P3/2P2N2/PP1P1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 c2c3 c5b6
 C64	Ruy Lopez: Classical Variation, Cordel Gambit	r1bqk1nr/pppp2pp/2n5/1Bb1pp2/4P3/2P2N2/PP1P1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 f8c5 c2c3 f7f5
@@ -989,9 +989,9 @@ C65	Ruy Lopez: Berlin Defense, Anderssen Variation	r1bqkb1r/ppp2ppp/2Bp1n2/4p3/4
 C65	Ruy Lopez: Berlin Defense, Beverwijk Variation	r1bqk2r/pppp1ppp/2n2n2/1Bb1p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f8c5
 C65	Ruy Lopez: Berlin Defense, Duras Variation	r1bqkb1r/ppp2ppp/2np1n2/1B2p3/2P1P3/3P1N2/PP3PPP/RNBQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 d7d6 c2c4
 C65	Ruy Lopez: Berlin Defense, Fishing Pole Variation	r1bqkb1r/pppp1ppp/2n5/1B2p3/4P1n1/5N2/PPPP1PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6g4
-C65	Ruy Lopez: Berlin Defense: Kaufmann Variation	r1bqk2r/pppp1ppp/2n2n2/1Bb1p3/4P3/3PBN2/PPP2PPP/RN1QK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 f8c5 c1e3
-C65	Ruy Lopez: Berlin Defense: Mortimer Trap	r1bqkb1r/pp1pnppp/2p2n2/1B2N3/4P3/3P4/PPP2PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 c6e7 f3e5 c7c6
-C65	Ruy Lopez: Berlin Defense: Mortimer Variation	r1bqkb1r/ppppnppp/5n2/1B2p3/4P3/3P1N2/PPP2PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 c6e7
+C65	Ruy Lopez: Berlin Defense, Kaufmann Variation	r1bqk2r/pppp1ppp/2n2n2/1Bb1p3/4P3/3PBN2/PPP2PPP/RN1QK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 f8c5 c1e3
+C65	Ruy Lopez: Berlin Defense, Mortimer Trap	r1bqkb1r/pp1pnppp/2p2n2/1B2N3/4P3/3P4/PPP2PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 c6e7 f3e5 c7c6
+C65	Ruy Lopez: Berlin Defense, Mortimer Variation	r1bqkb1r/ppppnppp/5n2/1B2p3/4P3/3P1N2/PPP2PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d3 c6e7
 C65	Ruy Lopez: Berlin Defense, Nyholm Attack	r1bqkb1r/pppp1ppp/2n2n2/1B6/3pP3/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 d2d4 e5d4 e1g1
 C65	Ruy Lopez: Berlin Defense	r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1
 C65	Ruy Lopez: Berlin Defense	r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6
@@ -1003,7 +1003,7 @@ C66	Ruy Lopez: Berlin Defense, Closed Wolf Variation	r2qkb1r/pppb1ppp/2np1n2/1B6
 C66	Ruy Lopez: Berlin Defense, Hedgehog Variation	r2qk2r/pppbbppp/2np1n2/1B2p3/3PP3/2N2N2/PPP2PPP/R1BQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 d7d6 d2d4 c8d7 b1c3 f8e7
 C66	Ruy Lopez: Berlin Defense, Improved Steinitz Defense	r1bqkb1r/ppp2ppp/2np1n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 d7d6
 C66	Ruy Lopez: Berlin Defense, Tarrasch Trap	r2q1rk1/pppbbppp/2np1n2/1B2p3/3PP3/2N2N2/PPP2PPP/R1BQR1K1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 d7d6 d2d4 c8d7 b1c3 g8f6 e1g1 f8e7 f1e1 e8g8
-C66	Ruy Lopez: Closed Berlin Defense: Chigorin Variation	r1bqkb1r/pppn1ppp/2np4/1B2p3/3PP3/5N2/PPP2PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 d7d6 d2d4 f6d7
+C66	Ruy Lopez: Closed Berlin Defense, Chigorin Variation	r1bqkb1r/pppn1ppp/2np4/1B2p3/3PP3/5N2/PPP2PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 d7d6 d2d4 f6d7
 C67	Ruy Lopez: Berlin Defense, Berlin Wall	r2k1b1r/pppb1ppp/2p5/4Pn2/8/2N2N2/PPP2PPP/R1B2RK1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5c6 d7c6 d4e5 d6f5 d1d8 e8d8 b1c3 c8d7
 C67	Ruy Lopez: Berlin Defense, Cordel Variation	r1bqk2r/p1ppbppp/2p5/4Pn2/8/5N2/PPP1QPPP/RNB2RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6f5
 C67	Ruy Lopez: Berlin Defense, l'Hermet Variation, Berlin Wall Defense	r1bk1b1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5c6 d7c6 d4e5 d6f5 d1d8 e8d8
@@ -1011,15 +1011,15 @@ C67	Ruy Lopez: Berlin Defense, l'Hermet Variation	r1bqkb1r/pppp1ppp/2nn4/1B2p3/3
 C67	Ruy Lopez: Berlin Defense, l'Hermet Variation, Westerinen Line	r1bqkb1r/ppp2ppp/2p5/4P3/4n3/5N2/PPP2PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5c6 d7c6 d4e5 d6e4
 C67	Ruy Lopez: Berlin Defense, Minckwitz Variation	r1bqk2r/ppppbppp/2n5/1B2P3/4n3/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d4e5
 C67	Ruy Lopez: Berlin Defense, Pillsbury Variation	r1bqk2r/pnppbppp/2p5/4P3/8/1P3N2/P1P1QPPP/RNB2RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6b7 b2b3
-C67	Ruy Lopez: Berlin Defense: Rio de Janeiro Variation	r1bq1rk1/p1ppbppp/8/2p1P3/3B4/2N5/PPP1QPPP/R3R1K1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6b7 b1c3 e8g8 f1e1 b7c5 f3d4 c5e6 c1e3 e6d4 e3d4 c6c5
+C67	Ruy Lopez: Berlin Defense, Rio de Janeiro Variation	r1bq1rk1/p1ppbppp/8/2p1P3/3B4/2N5/PPP1QPPP/R3R1K1 w - -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6b7 b1c3 e8g8 f1e1 b7c5 f3d4 c5e6 c1e3 e6d4 e3d4 c6c5
 C67	Ruy Lopez: Berlin Defense, Rio de Janeiro Variation	r1bqk2r/ppppbppp/2n5/1B2p3/3Pn3/5N2/PPP2PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7
 C67	Ruy Lopez: Berlin Defense, Rio Gambit Accepted	r1bqkb1r/pppp1ppp/2n5/1B2p3/4n3/5N2/PPPP1PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4
 C67	Ruy Lopez: Berlin Defense, Rosenthal Variation	r1bqkb1r/1ppp1ppp/p1n5/1B2p3/3Pn3/5N2/PPP2PPP/RNBQ1RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 a7a6
 C67	Ruy Lopez: Berlin Defense, Trifunovic Variation	r1bqk2r/ppp1bppp/2n5/1B1pp3/3Pn3/5N2/PPP1QPPP/RNB2RK1 w kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 d7d5
 C67	Ruy Lopez: Berlin Defense, Winawer Attack	r1bqk2r/pnppbppp/2p5/4P3/3N4/8/PPP1QPPP/RNB2RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6b7 f3d4
 C67	Ruy Lopez: Berlin Defense, Zukertort Variation	r1bqk2r/pnppbppp/2p5/4P3/2P5/5N2/PP2QPPP/RNB2RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 f8e7 d1e2 e4d6 b5c6 b7c6 d4e5 d6b7 c2c4
-C67	Ruy Lopez: Open Berlin Defense: l'Hermet Variation	r1bqkb1r/pppp1ppp/2nn4/1B2P3/8/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 d4e5
-C67	Ruy Lopez: Open Berlin Defense: Showalter Variation	r1bqkb1r/pppp1ppp/2nn4/4p3/B2P4/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5a4
+C67	Ruy Lopez: Open Berlin Defense, l'Hermet Variation	r1bqkb1r/pppp1ppp/2nn4/1B2P3/8/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 d4e5
+C67	Ruy Lopez: Open Berlin Defense, Showalter Variation	r1bqkb1r/pppp1ppp/2nn4/4p3/B2P4/5N2/PPP2PPP/RNBQ1RK1 b kq -	e2e4 e7e5 g1f3 b8c6 f1b5 g8f6 e1g1 f6e4 d2d4 e4d6 b5a4
 C68	Ruy Lopez: Exchange, Alekhine Variation	r3kbnr/1ppb1ppp/p1p5/8/3NP3/8/PPP2PPP/RNB1K2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 a7a6 b5c6 d7c6 d2d4 e5d4 d1d4 d8d4 f3d4 c8d7
 C68	Ruy Lopez: Exchange Variation, Alekhine Variation	r1b1k1nr/1pp2ppp/p1pb4/8/3NP3/8/PPP2PPP/RNB1K2R w KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 a7a6 b5c6 d7c6 d2d4 e5d4 d1d4 d8d4 f3d4 f8d6
 C68	Ruy Lopez: Exchange Variation, Keres Variation	r1bqkbnr/1pp2ppp/p1p5/4p3/4P3/2N2N2/PPPP1PPP/R1BQK2R b KQkq -	e2e4 e7e5 g1f3 b8c6 f1b5 a7a6 b5c6 d7c6 b1c3

--- a/d.tsv
+++ b/d.tsv
@@ -8,11 +8,11 @@ D00	Blackmar-Diemer Gambit: Bogoljubov Variation, Kloss Attack	rnbq1rk1/ppp1ppbp
 D00	Blackmar-Diemer Gambit: Bogoljubov Variation, Nimzowitsch Attack	rnbqk2r/ppp1ppbp/5np1/4N3/2BP4/2N5/PPP3PP/R1BQK2R b KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e4f3 g1f3 g7g6 f1c4 f8g7 f3e5
 D00	Blackmar-Diemer Gambit: Bogoljubov Variation	rnbqkb1r/ppp1pp1p/5np1/8/3P4/2N2N2/PPP3PP/R1BQKB1R w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 e4f3 g1f3 g7g6
 D00	Blackmar-Diemer Gambit: Bogoljubov Variation, Studier Attack	rnbq1rk1/ppp1ppbp/5np1/8/2BP4/2N2N2/PPP3PP/R1B1QRK1 b - -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 e4f3 g1f3 g7g6 f1c4 f8g7 e1g1 e8g8 d1e1
-D00	Blackmar-Diemer Gambit Declined, Brombacher Countergambit	rnbqkb1r/pp2pppp/5n2/2p5/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 c7c5
-D00	Blackmar-Diemer Gambit Declined, Elbert Countergambit	rnbqkb1r/ppp2ppp/5n2/4p3/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e7e5
-D00	Blackmar-Diemer Gambit Declined, Grosshans Defense	rn1qkbnr/pppbpppp/8/8/3Pp3/2N5/PPP2PPP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 c8d7
-D00	Blackmar-Diemer Gambit Declined, Lamb Defense	r1bqkb1r/ppp1pppp/2n2n2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 b8c6
-D00	Blackmar-Diemer Gambit Declined, Langeheinecke Defense	rnbqkb1r/ppp1pppp/5n2/8/3P4/2N1pP2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 e4e3
+D00	Blackmar-Diemer Gambit Declined: Brombacher Countergambit	rnbqkb1r/pp2pppp/5n2/2p5/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 c7c5
+D00	Blackmar-Diemer Gambit Declined: Elbert Countergambit	rnbqkb1r/ppp2ppp/5n2/4p3/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e7e5
+D00	Blackmar-Diemer Gambit Declined: Grosshans Defense	rn1qkbnr/pppbpppp/8/8/3Pp3/2N5/PPP2PPP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 c8d7
+D00	Blackmar-Diemer Gambit Declined: Lamb Defense	r1bqkb1r/ppp1pppp/2n2n2/8/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 b8c6
+D00	Blackmar-Diemer Gambit Declined: Langeheinecke Defense	rnbqkb1r/ppp1pppp/5n2/8/3P4/2N1pP2/PPP3PP/R1BQKBNR w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 e4e3
 D00	Blackmar-Diemer Gambit: Diemer-Rosenberg Attack	rnbqkbnr/ppp1pppp/8/8/3Pp3/4B3/PPP2PPP/RN1QKBNR b KQkq -	d2d4 d7d5 e2e4 d5e4 c1e3
 D00	Blackmar-Diemer Gambit: Euwe Defense	rnbqkb1r/ppp2ppp/4pn2/8/3P4/2N2N2/PPP3PP/R1BQKB1R w KQkq -	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 e4f3 g1f3 e7e6
 D00	Blackmar-Diemer Gambit: Euwe Defense, Zilbermints Gambit	r1bqk2r/ppp1bppp/4pn2/6B1/3n4/2NB1N2/PPP3PP/R2Q1R1K b kq -	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e4f3 g1f3 e7e6 c1g5 f8e7 f1d3 b8c6 e1g1 c6d4 g1h1
@@ -197,7 +197,7 @@ D21	Queen's Gambit Accepted: Godes Variation	r1bqkbnr/pppnpppp/8/8/2pP4/5N2/PP2P
 D21	Queen's Gambit Accepted: Gunsberg Defense	rnbqkbnr/pp2pppp/8/2p5/2pP4/5N2/PP2PPPP/RNBQKB1R w KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 c7c5
 D21	Queen's Gambit Accepted: Normal Variation	rnbqkbnr/ppp1pppp/8/8/2pP4/5N2/PP2PPPP/RNBQKB1R b KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3
 D21	Queen's Gambit Accepted: Slav Gambit	rnbqkbnr/p1p1pppp/8/1p6/2pP4/5N2/PP2PPPP/RNBQKB1R w KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 b7b5
-D22	Queen's Gambit Accepted: Alekhine Defense: Alatortsev Variation	rn1qkbnr/1pp2ppp/p3p3/3P4/2B3b1/4PN2/PP3PPP/RNBQK2R b KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 a7a6 e2e3 c8g4 f1c4 e7e6 d4d5
+D22	Queen's Gambit Accepted: Alekhine Defense, Alatortsev Variation	rn1qkbnr/1pp2ppp/p3p3/3P4/2B3b1/4PN2/PP3PPP/RNBQK2R b KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 a7a6 e2e3 c8g4 f1c4 e7e6 d4d5
 D22	Queen's Gambit Accepted: Alekhine Defense, Haberditz Variation	rnbqkbnr/2p1pppp/p7/1p6/2pP4/4PN2/PP3PPP/RNBQKB1R w KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 a7a6 e2e3 b7b5
 D22	Queen's Gambit Accepted: Alekhine Defense	rnbqkbnr/1pp1pppp/p7/8/2pP4/5N2/PP2PPPP/RNBQKB1R w KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 a7a6
 D23	Queen's Gambit Accepted: Mannheim Variation	rnbqkb1r/ppp1pppp/5n2/8/Q1pP4/5N2/PP2PPPP/RNB1KB1R b KQkq -	d2d4 d7d5 c2c4 d5c4 g1f3 g8f6 d1a4
@@ -373,12 +373,12 @@ D51	Queen's Gambit Declined: Modern, Knight Defense	r1bqkb1r/pp1n1ppp/2p1pn2/3p2
 D51	Queen's Gambit Declined: Modern, Knight Defense	r1bqkb1r/pppn1ppp/4pn2/3p2B1/2PP4/2N1P3/PP3PPP/R2QKBNR b KQkq -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 e2e3
 D51	Queen's Gambit Declined: Modern, Knight Defense	r1bqkb1r/pppn1ppp/4pn2/3p2B1/2PP4/2N5/PP2PPPP/R2QKBNR w KQkq -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7
 D51	Queen's Gambit Declined: Rochlin Variation	r1b1kb1r/pp1n1ppp/2p1pn2/q2p4/2PP4/2N2N2/PP1BPPPP/2RQKB1R b Kkq -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 g1f3 c7c6 a1c1 d8a5 g5d2
-D52	Queen's Gambit Declined: Cambridge Springs Defense: Argentine Variation	r1b2rk1/pp1n1ppp/2p1pn2/q2p4/1bPP3B/2N1P3/PPQN1PPP/R3KB1R b KQ -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 e2e3 c7c6 g1f3 d8a5 f3d2 f8b4 d1c2 e8g8 g5h4
-D52	Queen's Gambit Declined: Cambridge Springs Defense: Bogoljubov Variation	r1b1k2r/pp1n1ppp/2p1pn2/q2p2B1/1bPP4/2N1P3/PPQN1PPP/R3KB1R b KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 f3d2 f8b4 d1c2
-D52	Queen's Gambit Declined: Cambridge Springs Defense: Capablanca Variation	r1b1kb1r/pp1n1ppp/2p1pB2/q2p4/2PP4/2N1PN2/PP3PPP/R2QKB1R b KQkq -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 e2e3 c7c6 g1f3 d8a5 g5f6
+D52	Queen's Gambit Declined: Cambridge Springs Defense, Argentine Variation	r1b2rk1/pp1n1ppp/2p1pn2/q2p4/1bPP3B/2N1P3/PPQN1PPP/R3KB1R b KQ -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 e2e3 c7c6 g1f3 d8a5 f3d2 f8b4 d1c2 e8g8 g5h4
+D52	Queen's Gambit Declined: Cambridge Springs Defense, Bogoljubov Variation	r1b1k2r/pp1n1ppp/2p1pn2/q2p2B1/1bPP4/2N1P3/PPQN1PPP/R3KB1R b KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 f3d2 f8b4 d1c2
+D52	Queen's Gambit Declined: Cambridge Springs Defense, Capablanca Variation	r1b1kb1r/pp1n1ppp/2p1pB2/q2p4/2PP4/2N1PN2/PP3PPP/R2QKB1R b KQkq -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 b8d7 e2e3 c7c6 g1f3 d8a5 g5f6
 D52	Queen's Gambit Declined: Cambridge Springs Defense	r1b1kb1r/pp1n1ppp/2p1pn2/q2P2B1/3P4/2N1PN2/PP3PPP/R2QKB1R b KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 c4d5
-D52	Queen's Gambit Declined: Cambridge Springs Defense: Rubinstein Variation	r1b1kb1r/pp1n1ppp/2p1pn2/q5B1/2pP4/2N1P3/PP1N1PPP/R2QKB1R w KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 f3d2 d5c4
-D52	Queen's Gambit Declined: Cambridge Springs Defense: Yugoslav Variation	r1b1kb1r/pp1n1ppp/2p1p3/q2n2B1/3P4/2N1PN2/PP3PPP/R2QKB1R w KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 c4d5 f6d5
+D52	Queen's Gambit Declined: Cambridge Springs Defense, Rubinstein Variation	r1b1kb1r/pp1n1ppp/2p1pn2/q5B1/2pP4/2N1P3/PP1N1PPP/R2QKB1R w KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 f3d2 d5c4
+D52	Queen's Gambit Declined: Cambridge Springs Defense, Yugoslav Variation	r1b1kb1r/pp1n1ppp/2p1p3/q2n2B1/3P4/2N1PN2/PP3PPP/R2QKB1R w KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5 c4d5 f6d5
 D52	Queen's Gambit Declined: Cambridge Springs Variation	r1b1kb1r/pp1n1ppp/2p1pn2/q2p2B1/2PP4/2N1PN2/PP3PPP/R2QKB1R w KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3 d8a5
 D52	Queen's Gambit Declined	r1bqkb1r/pp1n1ppp/2p1pn2/3p2B1/2PP4/2N1PN2/PP3PPP/R2QKB1R b KQkq -	d2d4 d7d5 c2c4 c7c6 g1f3 g8f6 b1c3 e7e6 c1g5 b8d7 e2e3
 D53	Queen's Gambit Declined: Lasker Defense	rnbqk2r/ppp1bppp/4p3/3p2B1/2PPn3/2N1P3/PP3PPP/R2QKBNR w KQkq -	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c1g5 f8e7 e2e3 f6e4
@@ -392,7 +392,7 @@ D55	Queen's Gambit Declined: Neo-Orthodox Variation, Main Line	rnbq1rk1/ppp1bpp1
 D55	Queen's Gambit Declined: Neo-Orthodox Variation	rnbq1rk1/ppp1bpp1/4pn1p/3p2B1/2PP4/2N1PN2/PP3PPP/R2QKB1R w KQ -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 h7h6
 D55	Queen's Gambit Declined: Pillsbury Attack	rn1q1rk1/pbp1bppp/1p3n2/3pN1B1/3P4/2NBP3/PP3PPP/R2QK2R b KQ -	d2d4 g8f6 c2c4 e7e6 g1f3 b7b6 b1c3 d7d5 c4d5 e6d5 c1g5 f8e7 e2e3 e8g8 f1d3 c8b7 f3e5
 D56	Queen's Gambit Declined: Lasker Defense	rnbq1rk1/ppp1bpp1/4p2p/3p4/2PPn2B/2N1PN2/PP3PPP/R2QKB1R w KQ -	d2d4 d7d5 c2c4 e7e6 b1c3 f8e7 g1f3 g8f6 c1g5 h7h6 g5h4 e8g8 e2e3 f6e4
-D56	Queen's Gambit Declined: Lasker Defense: Russian Variation	r4rk1/pp1bqpp1/2n1pn1p/2p5/2BP4/2N1PN2/PPQ2PPP/R2R2K1 w - -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4 f6e4 h4e7 d8e7 d1c2 e4f6 f1d3 d5c4 d3c4 c7c5 e1g1 b8c6 f1d1 c8d7
+D56	Queen's Gambit Declined: Lasker Defense, Russian Variation	r4rk1/pp1bqpp1/2n1pn1p/2p5/2BP4/2N1PN2/PPQ2PPP/R2R2K1 w - -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4 f6e4 h4e7 d8e7 d1c2 e4f6 f1d3 d5c4 d3c4 c7c5 e1g1 b8c6 f1d1 c8d7
 D56	Queen's Gambit Declined: Lasker Defense, Teichmann Variation	rnb2rk1/ppp1qpp1/4p2p/3p4/2PPn3/2N1PN2/PPQ2PPP/R3KB1R b KQ -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 h7h6 g5h4 e8g8 e2e3 f6e4 h4e7 d8e7 d1c2
 D57	Queen's Gambit Declined: Lasker Defense, Bernstein Variation, Mar del Plata Gambit	rn1r2k1/ppp1qpp1/4b2p/3p4/2PP4/1Q2PN2/P4PPP/R3KB1R w KQ -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4 f6e4 h4e7 d8e7 c4d5 e4c3 b2c3 e6d5 d1b3 f8d8 c3c4 c8e6
 D57	Queen's Gambit Declined: Lasker Defense, Bernstein Variation	rnb2rk1/ppp2pp1/3q3p/3p4/3P4/1QP1PN2/P4PPP/R3KB1R w KQ -	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c1g5 f8e7 e2e3 h7h6 g5h4 e8g8 g1f3 f6e4 h4e7 d8e7 c4d5 e4c3 b2c3 e6d5 d1b3 e7d6
@@ -411,16 +411,16 @@ D63	Queen's Gambit Declined: Orthodox Defense, Henneberger Variation	r1bq1rk1/1p
 D63	Queen's Gambit Declined: Orthodox Defense, Main Line	r1bq1rk1/pp1nbppp/2p1pn2/3p2B1/2PP4/2N1PN2/PP3PPP/2RQKB1R w K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6
 D63	Queen's Gambit Declined: Orthodox Defense, Main Line	r1bq1rk1/pppnbppp/4pn2/3p2B1/2PP4/2N1PN2/PP3PPP/2RQKB1R b K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1
 D63	Queen's Gambit Declined: Orthodox Defense, Pillsbury Variation	r1bq1rk1/p1pnbppp/1p3n2/3p2B1/3P4/2NBPN2/PP3PPP/2RQK2R b K -	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 b7b6 c4d5 e6d5 f1d3
-D63	Queen's Gambit Declined: Orthodox Defense: Swiss, Karlsbad Variation	r1bq1rk1/1ppnbppp/p3pn2/3P2B1/3P4/2N1PN2/PP3PPP/2RQKB1R b K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 a7a6 c4d5
+D63	Queen's Gambit Declined: Orthodox Defense, Swiss, Karlsbad Variation	r1bq1rk1/1ppnbppp/p3pn2/3P2B1/3P4/2N1PN2/PP3PPP/2RQKB1R b K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 a7a6 c4d5
 D64	Queen's Gambit Declined: Orthodox Defense, Rubinstein Attack	r1bq1rk1/1p1nbppp/p1p1pn2/3p2B1/2PP4/2N1PN2/PPQ2PPP/2R1KB1R w K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 d1c2 a7a6
 D64	Queen's Gambit Declined: Orthodox Defense, Rubinstein Attack	r1bq1rk1/1p1nbppp/p1p1pn2/3p2B1/2PP4/P1N1PN2/1PQ2PPP/2R1KB1R b K -	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 g1f3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 a2a3 a7a6 d1c2
 D64	Queen's Gambit Declined: Orthodox Defense, Rubinstein Attack	r1bq1rk1/pp1nbppp/2p1p3/3p2B1/2PPn3/2N1PN2/PPQ2PPP/2R1KB1R w K -	g1f3 d7d5 d2d4 g8f6 c2c4 e7e6 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 d1c2 f6e4
-D64	Queen's Gambit Declined: Orthodox Defense: Rubinstein Attack	r1bq1rk1/pp1nbppp/2p1pn2/3p2B1/2PP4/2N1PN2/PPQ2PPP/2R1KB1R b K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 d1c2
+D64	Queen's Gambit Declined: Orthodox Defense, Rubinstein Attack	r1bq1rk1/pp1nbppp/2p1pn2/3p2B1/2PP4/2N1PN2/PPQ2PPP/2R1KB1R b K -	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 d1c2
 D65	Queen's Gambit Declined: Orthodox Defense, Rubinstein Attack	r1bq1rk1/1p1nbppp/p1p1pn2/3P2B1/3P4/2N1PN2/PPQ2PPP/2R1KB1R b K -	d2d4 d7d5 g1f3 g8f6 c2c4 e7e6 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 d1c2 a7a6 c4d5
-D66	Queen's Gambit Declined: Orthodox Defense: Bd3 Line	r1bq1rk1/pp1nbppp/2p1pn2/3p2B1/2PP4/2NBPN2/PP3PPP/2RQK2R b K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3
+D66	Queen's Gambit Declined: Orthodox Defense, Bd3 Line	r1bq1rk1/pp1nbppp/2p1pn2/3p2B1/2PP4/2NBPN2/PP3PPP/2RQK2R b K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3
 D66	Queen's Gambit Declined: Orthodox Defense, Fianchetto Variation	r1bq1rk1/p2nbppp/2p1pn2/1p4B1/2BP4/2N1PN2/PP3PPP/2RQK2R w K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 c7c6 g1f3 f8e7 e2e3 b8d7 a1c1 e8g8 f1d3 d5c4 d3c4 b7b5
 D67	Queen's Gambit Declined: Orthodox Defense, Alekhine Variation	r1b2rk1/pp1nqppp/2p1p3/3n4/2BPN3/4PN2/PP3PPP/2RQK2R b K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5 g5e7 d8e7 c3e4
-D67	Queen's Gambit Declined: Orthodox Defense: Bd3 Line	r1b2rk1/pp1nqppp/2p1p3/3n4/2BP4/2N1PN2/PP3PPP/2RQK2R w K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5 g5e7 d8e7
+D67	Queen's Gambit Declined: Orthodox Defense, Bd3 Line	r1b2rk1/pp1nqppp/2p1p3/3n4/2BP4/2N1PN2/PP3PPP/2RQK2R w K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5 g5e7 d8e7
 D67	Queen's Gambit Declined: Orthodox Defense, Capablanca System	r1bq1rk1/pp1nbppp/2p1p3/3n2B1/2BP4/2N1PN2/PP3PPP/2RQK2R w K -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5
 D67	Queen's Gambit Declined: Orthodox Defense, Janowski Variation	r1bq1rk1/pp1nbppp/2p1p3/3n2B1/2BP3P/2N1PN2/PP3PP1/2RQK2R b K -	d2d4 d7d5 g1f3 g8f6 c2c4 e7e6 b1c3 f8e7 c1g5 e8g8 e2e3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5 h2h4
 D67	Queen's Gambit Declined: Orthodox Defense, Main Line	r1b2rk1/pp1nqppp/2p1p3/3n4/2BP4/2N1PN2/PP3PPP/2RQ1RK1 b - -	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 b8d7 a1c1 c7c6 f1d3 d5c4 d3c4 f6d5 g5e7 d8e7 e1g1


### PR DESCRIPTION
Change Accpeted and Declined gambits, so they will be in the format
'Benko Gambit Accepted, Dlugy Variation' but in 'Benko Gambit Accepted: Dlugy Variation'
This change makes gambits similar to chess.com structure and allows grouping by common prefix