### PR TITLE
Improvements to Kieseritzky Gambit

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -494,7 +494,7 @@ C39	King's Gambit Accepted: Allgaier, Urusov Attack	rnbq1bnr/ppp3k1/7p/3B4/3PPpp
 C39	King's Gambit Accepted: Kieseritzky Gambit, Anderssen-Cordel Gambit	rnbqk2r/ppp2p1p/3b4/3PN3/2BP1npP/8/PPP3P1/RN1QK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 d2d4 f6h5 c1f4 h5f4
 C39	King's Gambit Accepted: Kieseritzky Gambit, Anderssen Defense	rnbqk2r/ppp2p1p/3b1n2/3PN3/2B2ppP/8/PPPP2P1/RNBQK2R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6
 C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense, de Riviere Variation	rnbqkb1r/ppp2p1p/5n2/3p4/4PpNP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 e5g4 d7d5
-C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/2B1PppP/8/PPPP2P1/RNBQK2R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4
+C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense, Rubinstein Variation	rnbqkb1r/pppp1p1p/5n2/4N3/3PPppP/8/PPP3P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 d2d4
 C39	King's Gambit Accepted: Kieseritzky Gambit, Berlin Defense	rnbqkb1r/pppp1p1p/5n2/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6
 C39	King's Gambit Accepted: Kieseritzky Gambit, Brentano Defense, Caro Variation	rnbqkb1r/ppp2p1p/8/3pN3/3PnBpP/8/PPPN2P1/R2QKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5 d2d4 g8f6 c1f4 f6e4 b1d2
 C39	King's Gambit Accepted: Kieseritzky Gambit, Brentano Defense, Kaplanek Variation	rnb1k2r/ppp2p1p/5n2/3qN3/1b1P1ppP/2N5/PPP2KP1/R1BQ1B1R b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d7d5 d2d4 g8f6 e4d5 d8d5 b1c3 f8b4 e1f2
@@ -508,7 +508,7 @@ C39	King's Gambit Accepted: Kieseritzky Gambit, Paulsen Defense Deferred	rnbqk2r
 C39	King's Gambit Accepted: Kieseritzky Gambit, Paulsen Defense	rnbqk1nr/pppp1pbp/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 f8g7
 C39	King's Gambit Accepted: Kieseritzky Gambit, Rice Gambit	rnbqk2r/ppp2p1p/5n2/3Pb3/2B2ppP/8/PPPP2P1/RNBQ1RK1 w kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 e1g1 d6e5
 C39	King's Gambit Accepted: Kieseritzky Gambit, Rosenthal Defense	rnb1kbnr/ppppqp1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 d8e7
-C39	King's Gambit Accepted: Kieseritzky Gambit, Rubinstein Variation	rnbqkb1r/pppp1p1p/5n2/4N3/3PPppP/8/PPP3P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 d2d4
+C39	King's Gambit Accepted: Kieseritzky Gambit	rnbqkbnr/pppp1p1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R b KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5
 C39	King's Gambit Accepted: Kieseritzky, Long Whip Defense, Jaenisch Variation	rnbqk1n1/pppp1p1r/7b/4N2p/2BPPppP/2N5/PPP3P1/R1BQK2R b KQq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 h7h5 f1c4 h8h7 d2d4 f8h6 b1c3
 C39	King's Gambit Accepted: Kieseritzky, Polerio Defense	rnbqk1nr/ppppbp1p/8/4N3/4PppP/8/PPPP2P1/RNBQKB1R w KQkq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 f8e7
 C39	King's Gambit Accepted: Kieseritzky, Rice Gambit	rnbqk2r/ppp2p1p/3b1n2/3PN3/2B2ppP/8/PPPP2P1/RNBQ1RK1 b kq -	e2e4 e7e5 f2f4 e5f4 g1f3 g7g5 h2h4 g5g4 f3e5 g8f6 f1c4 d7d5 e4d5 f8d6 e1g1


### PR DESCRIPTION
- There was no base position for the Kieseritzky Gambit yet
- Kieseritzky Gambit, Berlin Defense was reached twice, with the second one just one move further in the continuation. 
- Rubinstein Variation is actually a subvariation of the Berlin Defense

PS: I'm the one who made all these opening changes a week ago to ornicar/scalachess, so... from now on I'll put them here?